### PR TITLE
improve build performance

### DIFF
--- a/src/build/buildExecutor.ts
+++ b/src/build/buildExecutor.ts
@@ -12,7 +12,7 @@ export class BuildExecutor {
     private cwd: string;
     private binary: string;
     private runningChildProcess: ChildProcess;
-    private skipRestore: boolean;
+    private static skipRestore: boolean;
 
     constructor(platformInfo: PlatformInformation, private environmentController: EnvironmentController, private eventStream: EventStream) {
         let runtimeDependencies = <Package[]>PACKAGE_JSON.runtimeDependencies;
@@ -20,7 +20,6 @@ export class BuildExecutor {
         let absolutePackage = AbsolutePathPackage.getAbsolutePathPackage(buildPackage, EXTENSION_PATH);
         this.cwd = absolutePackage.installPath.value;
         this.binary = absolutePackage.binary;
-        this.skipRestore = false;
     }
 
     public async RunBuild(
@@ -39,11 +38,11 @@ export class BuildExecutor {
             'DOCS_ENVIRONMENT': this.environmentController.env
         };
 
-        if (!this.skipRestore) {
+        if (!BuildExecutor.skipRestore) {
             if (!(await this.restore(repositoryPath, outputPath, buildUserToken, envs))) {
                 return false;
             }
-            this.skipRestore = true;
+            BuildExecutor.skipRestore = true;
         }
 
         return await this.build(repositoryPath, outputPath, envs);

--- a/src/build/buildExecutor.ts
+++ b/src/build/buildExecutor.ts
@@ -7,7 +7,6 @@ import { DocfxRestoreCanceled, DocfxRestoreFailed, DocfxRestoreSucceeded, DocfxB
 import { EnvironmentController } from '../common/EnvironmentController';
 import { EventStream } from '../common/EventStream';
 import { executeDocfx } from '../utils/childProcessUtils';
-import { basicAuth } from '../utils/utils';
 
 export class BuildExecutor {
     private cwd: string;
@@ -62,22 +61,14 @@ export class BuildExecutor {
         buildUserToken: string,
         envs: any): Promise<boolean> {
         return new Promise((resolve, reject) => {
-            let secrets = <any>{
-                [`${extensionConfig.OPBuildAPIEndPoint[this.environmentController.env]}`]: {
-                    "headers": {
-                        "X-OP-BuildUserToken": buildUserToken
+            let stdinInput = JSON.stringify({
+                "http": {
+                    [`${extensionConfig.OPBuildAPIEndPoint[this.environmentController.env]}`]: {
+                        "headers": {
+                            "X-OP-BuildUserToken": buildUserToken
+                        }
                     }
                 }
-            };
-            if (process.env.VSCODE_DOCS_BUILD_EXTENSION_GITHUB_TOKEN) {
-                secrets["https://github.com"] = {
-                    "headers": {
-                        "authorization": `basic ${basicAuth(process.env.VSCODE_DOCS_BUILD_EXTENSION_GITHUB_TOKEN)}`
-                    }
-                };
-            }
-            let stdinInput = JSON.stringify({
-                "http": secrets
             });
             this.eventStream.post(new DocfxRestoreStarted());
             let command = `${this.binary} restore "${repositoryPath}" --legacy --output ${outputPath} --stdin`;

--- a/src/build/buildExecutor.ts
+++ b/src/build/buildExecutor.ts
@@ -3,15 +3,17 @@ import { PACKAGE_JSON, EXTENSION_PATH, extensionConfig } from '../shared';
 import { PlatformInformation } from '../common/PlatformInformation';
 import { ChildProcess } from 'child_process';
 import { Package, AbsolutePathPackage } from '../dependency/Package';
-import { DocfxRestoreCanceled, DocfxRestoreFailed, DocfxRestoreSucceeded, DocfxBuildCanceled, DocfxBuildSucceeded, DocfxBuildFailed } from '../common/loggingEvents';
+import { DocfxRestoreCanceled, DocfxRestoreFailed, DocfxRestoreSucceeded, DocfxBuildCanceled, DocfxBuildSucceeded, DocfxBuildFailed, DocfxBuildStarted, DocfxRestoreStarted } from '../common/loggingEvents';
 import { EnvironmentController } from '../common/EnvironmentController';
 import { EventStream } from '../common/EventStream';
 import { executeDocfx } from '../utils/childProcessUtils';
+import { basicAuth } from '../utils/utils';
 
 export class BuildExecutor {
     private cwd: string;
     private binary: string;
     private runningChildProcess: ChildProcess;
+    private skipRestore: boolean;
 
     constructor(platformInfo: PlatformInformation, private environmentController: EnvironmentController, private eventStream: EventStream) {
         let runtimeDependencies = <Package[]>PACKAGE_JSON.runtimeDependencies;
@@ -19,6 +21,7 @@ export class BuildExecutor {
         let absolutePackage = AbsolutePathPackage.getAbsolutePathPackage(buildPackage, EXTENSION_PATH);
         this.cwd = absolutePackage.installPath.value;
         this.binary = absolutePackage.binary;
+        this.skipRestore = false;
     }
 
     public async RunBuild(
@@ -37,9 +40,11 @@ export class BuildExecutor {
             'DOCS_ENVIRONMENT': this.environmentController.env
         };
 
-        // TODO: Restore on VS Code restore instead of every build
-        if (!(await this.restore(repositoryPath, outputPath, buildUserToken, envs))) {
-            return false;
+        if (!this.skipRestore) {
+            if (!(await this.restore(repositoryPath, outputPath, buildUserToken, envs))) {
+                return false;
+            }
+            this.skipRestore = true;
         }
 
         return await this.build(repositoryPath, outputPath, envs);
@@ -57,15 +62,24 @@ export class BuildExecutor {
         buildUserToken: string,
         envs: any): Promise<boolean> {
         return new Promise((resolve, reject) => {
-            let stdinInput = JSON.stringify({
-                "http": {
-                    [`${extensionConfig.OPBuildAPIEndPoint[this.environmentController.env]}`]: {
-                        "headers": {
-                            "X-OP-BuildUserToken": buildUserToken
-                        }
+            let secrets = <any>{
+                [`${extensionConfig.OPBuildAPIEndPoint[this.environmentController.env]}`]: {
+                    "headers": {
+                        "X-OP-BuildUserToken": buildUserToken
                     }
                 }
+            };
+            if (process.env.VSCODE_DOCS_BUILD_EXTENSION_GITHUB_TOKEN) {
+                secrets["https://github.com"] = {
+                    "headers": {
+                        "authorization": `basic ${basicAuth(process.env.VSCODE_DOCS_BUILD_EXTENSION_GITHUB_TOKEN)}`
+                    }
+                };
+            }
+            let stdinInput = JSON.stringify({
+                "http": secrets
             });
+            this.eventStream.post(new DocfxRestoreStarted());
             let command = `${this.binary} restore "${repositoryPath}" --legacy --output ${outputPath} --stdin`;
             this.runningChildProcess = executeDocfx(
                 command,
@@ -94,7 +108,8 @@ export class BuildExecutor {
         outputPath: string,
         envs: any): Promise<boolean> {
         return new Promise((resolve, reject) => {
-            let command = `${this.binary} build "${repositoryPath}" --legacy --output ${outputPath}`;
+            this.eventStream.post(new DocfxBuildStarted());
+            let command = `${this.binary} build "${repositoryPath}" --legacy --dry-run --output ${outputPath}`;
             this.runningChildProcess = executeDocfx(
                 command,
                 this.eventStream,

--- a/src/common/loggingEvents.ts
+++ b/src/common/loggingEvents.ts
@@ -92,7 +92,6 @@ export class BuildProgress implements BaseEvent {
 
 export class DocfxRestoreStarted implements BaseEvent {
     type = EventType.DocfxRestoreStarted;
-    constructor(public workSpaceFolderName: string) { }
 }
 
 export class DocfxRestoreFinished implements BaseEvent {
@@ -114,7 +113,6 @@ export class DocfxRestoreCanceled implements BaseEvent {
 
 export class DocfxBuildStarted implements BaseEvent {
     type = EventType.DocfxBuildStarted;
-    constructor(public workSpaceFolderName: string) { }
 }
 
 export class DocfxBuildFinished implements BaseEvent {


### PR DESCRIPTION
improve:
1. restore on VS Code re-open
2. support `dry run` mode(validation-only)

performance data:
> Note: all of this data is collected after warm up(all dependency has been restored)

# Current:

| azure-docs-pr | docs | edge-developer | sql-docs-pr |
|  --- | --- | --- | --- |
| 00:02:09 | 00:01:25 | 00:00:09 | 00:01:56 |

# Restore on VS Code re-open:
| azure-docs-pr | docs | edge-developer | sql-docs-pr |
|  --- | --- | --- | --- |
| 00:01:42 | 00:01:15 | 00:00:04 | 00:01:54 |

# Restore on VS Code re-open + Dry run:

| azure-docs-pr | docs | edge-developer | sql-docs-pr |
|  --- | --- | --- | --- |
| 00:00:37 | 00:00:37 | 00:00:03 | 00:00:49 |
