### PR TITLE
Fix sign in failure on chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -450,11 +450,6 @@
       "integrity": "sha512-Z4TYuEKn9+RbNVk1Ll2SS4x1JeLHecolIbM/a8gveaHsW0Hr+RQMraZACwTO2VD7JvepgA6UO1A1VrbktQrIbQ==",
       "dev": true
     },
-    "@types/url-template": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@types/url-template/-/url-template-2.0.28.tgz",
-      "integrity": "sha512-1i/YtOhvlWDbMDTWhCfvhyUwBS9vNFs78sJOyahoruJCcDbwaSH73AlnuCp7luKPm6qqdCg4VKq/IHUncl6gZA=="
-    },
     "@types/uuid": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.7.tgz",
@@ -8752,11 +8747,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
       "dev": true
-    },
-    "url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "urlgrey": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "@types/keytar": "^4.4.0",
     "@types/mkdirp": "^0.5.2",
     "@types/request": "^2.48.4",
-    "@types/url-template": "^2.0.28",
     "@types/uuid": "^3.4.7",
     "@types/yauzl": "^2.9.1",
     "arch": "^2.1.1",
@@ -165,7 +164,6 @@
     "request": "^2.88.0",
     "rxjs": "^6.5.3",
     "simple-git": "^1.129.0",
-    "url-template": "^2.0.8",
     "uuid": "^3.4.0",
     "vscode-extension-telemetry": "^0.1.2",
     "yauzl": "^2.10.0"

--- a/src/credential/credentialController.ts
+++ b/src/credential/credentialController.ts
@@ -92,7 +92,6 @@ export class CredentialController {
     }
 
     private resetCredential() {
-        this.keyChain.resetAADInfo();
         this.keyChain.resetUserInfo();
         this.signInStatus = 'SignedOut';
         this.userInfo = undefined;
@@ -101,8 +100,7 @@ export class CredentialController {
 
     private async refreshCredential(): Promise<void> {
         let userInfo = await this.keyChain.getUserInfo();
-        let aadInfo = await this.keyChain.getAADInfo();
-        if (userInfo && aadInfo) {
+        if (userInfo) {
             this.signInStatus = 'SignedIn';
             this.userInfo = userInfo;
             this.eventStream.post(new CredentialRetrieveFromLocalCredentialManager(this.credential));

--- a/src/credential/keyChain.ts
+++ b/src/credential/keyChain.ts
@@ -31,14 +31,6 @@ export class KeyChain {
         this.keytar = overwriteKeytar || getNodeModule<Keytar>('keytar') || failingKeytar;
     }
 
-    public async getAADInfo(): Promise<string> {
-        let aadInfo = await this.keytar.getPassword(SERVICE_ID, this.AADAccountId);
-        if (aadInfo) {
-            return aadInfo;
-        }
-        return undefined;
-    }
-
     public async getUserInfo(): Promise<UserInfo | null> {
         let userInfoStr = await this.keytar.getPassword(SERVICE_ID, this.userInfoAccountId);
         if (userInfoStr) {
@@ -47,24 +39,12 @@ export class KeyChain {
         return undefined;
     }
 
-    public async setAADInfo(aadInfo: string): Promise<void> {
-        await this.keytar.setPassword(SERVICE_ID, this.AADAccountId, aadInfo);
-    }
-
     public async setUserInfo(userInfo: UserInfo): Promise<void> {
         await this.keytar.setPassword(SERVICE_ID, this.userInfoAccountId, JSON.stringify(userInfo));
     }
 
     public async resetUserInfo(): Promise<void> {
         await this.keytar.deletePassword(SERVICE_ID, this.userInfoAccountId);
-    }
-
-    public async resetAADInfo(): Promise<void> {
-        await this.keytar.deletePassword(SERVICE_ID, this.AADAccountId);
-    }
-
-    private get AADAccountId(): string {
-        return `docs-build-aad-${this.environmentController.env}`;
     }
 
     private get userInfoAccountId(): string {

--- a/src/error/errorCode.ts
+++ b/src/error/errorCode.ts
@@ -1,10 +1,7 @@
 export enum ErrorCode {
     // Sign
-    AADSignInTimeOut = 'AADSignInTimeOut',
     GitHubSignInTimeOut = 'GitHubSignInTimeOut',
-    AADSignInExternalUrlDeclined = 'AADSignInExternalUrlDeclined',
     GitHubSignInExternalUrlDeclined = 'GitHubSignInExternalUrlDeclined',
-    AADSignInFailed = 'AADSignInFailed',
     GitHubSignInFailed = 'GitHubSignInFailed',
 
     // Build

--- a/test/unitTests/credential/keychain.test.ts
+++ b/test/unitTests/credential/keychain.test.ts
@@ -32,20 +32,6 @@ describe('KeyChain', () => {
         keyChain = new KeyChain(environmentController, new MockKeytar());
     });
 
-    it('getAADInfo gets tokens set by setAADInfo with the same environment', async () => {
-        setEnvToPROD(environmentController);
-        await keyChain.setAADInfo('fake-aad');
-        let aadInfo = await keyChain.getAADInfo();
-        assert.equal(aadInfo, 'fake-aad');
-
-        // Mock PPE environment
-        setEnvToPPE(environmentController);
-
-        // Test
-        aadInfo = await keyChain.getAADInfo();
-        assert.equal(aadInfo, undefined);
-    });
-
     it('setUserInfo gets tokens set by setToken with the same environment', async () => {
         setEnvToPROD(environmentController);
         let expectedUserInfo = <UserInfo>{
@@ -64,16 +50,6 @@ describe('KeyChain', () => {
         // Test
         userInfo = await keyChain.getUserInfo();
         assert.equal(userInfo, undefined);
-    });
-
-    it('getAADInfo no longer returns removed tokens', async () => {
-        await keyChain.setAADInfo('fake-aad');
-        let aadInfo = await keyChain.getAADInfo();
-        assert.equal(aadInfo, 'fake-aad');
-
-        await keyChain.resetAADInfo();
-        aadInfo = await keyChain.getAADInfo();
-        assert.equal(aadInfo, undefined);
     });
 
     it('setUserInfo no longer returns removed tokens', async () => {

--- a/test/unitTests/observers/docsLoggerObserver.test.ts
+++ b/test/unitTests/observers/docsLoggerObserver.test.ts
@@ -28,7 +28,6 @@ describe('DocsLoggerObserver', () => {
         it(`UserSignInSucceeded`, () => {
             let event = new UserSignInSucceeded('FakedCorrelationId', <Credential>{
                 signInStatus: 'SignedIn',
-                aadInfo: 'faked-aad',
                 userInfo: {
                     signType: 'GitHub',
                     userEmail: 'fake@microsoft.com',
@@ -57,7 +56,6 @@ describe('DocsLoggerObserver', () => {
     it(`CredentialRetrieveFromLocalCredentialManager`, () => {
         let event = new CredentialRetrieveFromLocalCredentialManager(<Credential>{
             signInStatus: 'SignedIn',
-            aadInfo: 'faked-aad',
             userInfo: {
                 signType: 'GitHub',
                 userEmail: 'fake@microsoft.com',

--- a/test/unitTests/observers/signStatusBarObserver.test.ts
+++ b/test/unitTests/observers/signStatusBarObserver.test.ts
@@ -48,7 +48,6 @@ describe('SignStatusBarObserver', () => {
     it(`User Signed In: Status bar is shown with user info`, () => {
         let event = new UserSignInSucceeded('FakedCorrelationId', <Credential>{
             signInStatus: 'SignedIn',
-            aadInfo: 'fake-add',
             userInfo: {
                 signType: 'GitHub',
                 userEmail: 'fake@microsoft.com',
@@ -66,7 +65,6 @@ describe('SignStatusBarObserver', () => {
     it(`Fetch From Local Credential Manager: Status bar is shown with user info`, () => {
         let event = new CredentialRetrieveFromLocalCredentialManager(<Credential>{
             signInStatus: 'SignedIn',
-            aadInfo: 'fake-add',
             userInfo: {
                 signType: 'GitHub',
                 userEmail: 'fake@microsoft.com',

--- a/test/unitTests/observers/telemetryObserver.test.ts
+++ b/test/unitTests/observers/telemetryObserver.test.ts
@@ -52,7 +52,6 @@ describe('TelemetryObserver', () => {
         it('UserSignInSucceeded', () => {
             let event = new UserSignInSucceeded('fakedCorrelationId', <Credential>{
                 signInStatus: 'SignedIn',
-                aadInfo: 'faked-aad',
                 userInfo: {
                     signType: 'GitHub',
                     userEmail: 'fake@microsoft.com',
@@ -73,7 +72,7 @@ describe('TelemetryObserver', () => {
         });
 
         it('UserSignInFailed', () => {
-            let event = new UserSignInFailed('fakedCorrelationId', new DocsError('Faked error message', ErrorCode.AADSignInFailed));
+            let event = new UserSignInFailed('fakedCorrelationId', new DocsError('Faked error message', ErrorCode.GitHubSignInFailed));
             observer.eventHandler(event);
             assert.equal(sentEventName, 'SignIn.Completed');
             assert.deepStrictEqual(sentEventProperties, {
@@ -82,7 +81,7 @@ describe('TelemetryObserver', () => {
                 SignInType: undefined,
                 UserName: undefined,
                 UserEmail: undefined,
-                ErrorCode: 'AADSignInFailed',
+                ErrorCode: 'GitHubSignInFailed',
             });
         });
     });

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -20,7 +20,6 @@ export async function ensureExtensionActivatedAndInitializationFinished(): Promi
 }
 
 export function setupAvailableMockKeyChain(sinon: SinonSandbox, keyChain: KeyChain) {
-    sinon.stub(keyChain, 'getAADInfo').resolves('fake-code');
     if (!process.env.VSCODE_DOCS_BUILD_EXTENSION_BUILD_USER_TOKEN) {
         console.error('Cannot get "VSCODE_DOCS_BUILD_EXTENSION_BUILD_USER_TOKEN" from environment variable');
     }
@@ -34,7 +33,6 @@ export function setupAvailableMockKeyChain(sinon: SinonSandbox, keyChain: KeyCha
 }
 
 export function setupUnavailableMockKeyChain(sinon: SinonSandbox, keyChain: KeyChain) {
-    sinon.stub(keyChain, 'getAADInfo').resolves(undefined);
     sinon.stub(keyChain, 'getUserInfo').resolves(undefined);
 }
 


### PR DESCRIPTION
Fix sign in failure by merging the 2 step sign in flow into a 1 step sign in flow.

### Background

To prevent launching external protocols without user interaction, chrome only allows launching external protocol like `vscode://` [after user interaction](https://github.com/chromium/chromium/blob/ccd149af47315e4c6f2fc45d55be1b271f39062c/chrome/browser/external_protocol/external_protocol_handler.cc#L39). So only the first `openExternal` request redirects back to `vscode`.

But if you happened to installed any chrome extension that listens to the `chrome.tabs.update` event, you can be redirect to `vscode` anytime, because chrome [bypasses](https://github.com/chromium/chromium/blob/ccd149af47315e4c6f2fc45d55be1b271f39062c/extensions/browser/extension_function_dispatcher.cc#L392) the above external link protection once when a new tab opens. This is to fix a chrome extension [bug](crbug.com/39178). `chrome.tabs.update` event also uses external protocol `chrome://` and is subject to the above protection.

To address this issue, we can leverage HTTP redirect and call `openExternal` only once like other extensions.

### Notes:

- An OPS server bug prevents us from adding Window query string, this can cause signin failure when multiple vscode window is opened. (Can repo this easily in debugging)
- A `vscode.Uri` bug prevents us from opening links with nested encoding, use `<any>` cast to workaround the problem.
- Remove `aadInfo` and related functionality as we are sign in using GitHub to obtain an OPS token.
- Replace `url-template` with the builtin `querystring`

#58
https://dev.azure.com/ceapex/Engineering/_workitems/edit/179448
