### PR TITLE
import source code from vscode-extension-telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -834,14 +834,14 @@
       }
     },
     "applicationinsights": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.0.tgz",
-      "integrity": "sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.2.tgz",
+      "integrity": "sha512-AtofsH08vrGTMDwXVK6+1wITd8ou9gksFV95JLZo7lVL0wX7/W1qeAZ13DK/6P3VJVsSMJ0sjdVNn98C4XxGvw==",
       "requires": {
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "^0.3.2"
+        "diagnostic-channel-publishers": "^0.3.3"
       }
     },
     "aproba": {
@@ -8931,14 +8931,6 @@
         "url-join": "^1.1.0",
         "yauzl": "^2.3.1",
         "yazl": "^2.2.2"
-      }
-    },
-    "vscode-extension-telemetry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz",
-      "integrity": "sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==",
-      "requires": {
-        "applicationinsights": "1.4.0"
       }
     },
     "vscode-test": {

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@types/request": "^2.48.4",
     "@types/uuid": "^3.4.7",
     "@types/yauzl": "^2.9.1",
+    "applicationinsights": "^1.7.2",
     "arch": "^2.1.1",
     "du": "^1.0.0",
     "fs-extra": "^8.1.0",
@@ -165,7 +166,6 @@
     "rxjs": "^6.5.3",
     "simple-git": "^1.129.0",
     "uuid": "^3.4.0",
-    "vscode-extension-telemetry": "^0.1.2",
     "yauzl": "^2.10.0"
   },
   "runtimeDependencies": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,4 @@
 import vscode from 'vscode';
-import TelemetryReporter from 'vscode-extension-telemetry';
 import { CredentialController } from './credential/credentialController';
 import { uriHandler, EXTENSION_ID } from './shared';
 import { PlatformInformation } from './common/platformInformation';
@@ -23,6 +22,7 @@ import { EnvironmentController } from './common/environmentController';
 import { TelemetryObserver } from './observers/telemetryObserver';
 import { getCorrelationId } from './utils/utils';
 import { QuickPickTriggered, QuickPickCommandSelected } from './common/loggingEvents';
+import TelemetryReporter from './telemetryReporter';
 
 export async function activate(context: vscode.ExtensionContext): Promise<ExtensionExports> {
     const eventStream = new EventStream();

--- a/src/observers/telemetryObserver.ts
+++ b/src/observers/telemetryObserver.ts
@@ -1,10 +1,10 @@
 import { BaseEvent, UserSignInTriggered, UserSignInCompleted, UserSignInSucceeded, UserSignInFailed, UserSignOutTriggered, UserSignOutCompleted, BuildTriggered, BuildCompleted, BuildSucceeded, BuildFailed, BuildCacheSizeCalculated, LearnMoreClicked, QuickPickTriggered, QuickPickCommandSelected, DependencyInstallStarted, DependencyInstallCompleted, PackageInstallCompleted } from '../common/loggingEvents';
-import TelemetryReporter from 'vscode-extension-telemetry';
 import { EventType } from '../common/eventType';
 import { DocsSignInType } from '../shared';
 import { DocsError } from '../error/docsError';
 import { BuildType } from '../build/buildInput';
 import { DocfxExecutionResult } from '../build/buildResult';
+import TelemetryReporter from '../telemetryReporter';
 
 export class TelemetryObserver {
     constructor(private reporter: TelemetryReporter) { }

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+/* tslint:disable */
+(process.env['APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL'] as any) = true;
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import * as appInsights from 'applicationinsights';
+
+export default class TelemetryReporter {
+    public userOptIn: boolean = false;
+
+    private appInsightsClient: appInsights.TelemetryClient | undefined;
+    private readonly configListener: vscode.Disposable;
+
+    private static TELEMETRY_CONFIG_ID = 'telemetry';
+    private static TELEMETRY_CONFIG_ENABLED_ID = 'enableTelemetry';
+
+    private logStream: fs.WriteStream | undefined;
+    private customCommonProperties: {
+        [key: string]: string;
+    } = {};
+
+    // tslint:disable-next-line
+    constructor(private extensionId: string, private extensionVersion: string, key: string) {
+        let logFilePath = process.env['VSCODE_LOGS'] || '';
+        if (logFilePath && extensionId && process.env['VSCODE_LOG_LEVEL'] === 'trace') {
+            logFilePath = path.join(logFilePath, `${extensionId}.txt`);
+            this.logStream = fs.createWriteStream(logFilePath, { flags: 'a', encoding: 'utf8', autoClose: true });
+        }
+        this.updateUserOptIn(key);
+        this.configListener = vscode.workspace.onDidChangeConfiguration(() => this.updateUserOptIn(key));
+    }
+
+    private updateUserOptIn(key: string): void {
+        const config = vscode.workspace.getConfiguration(TelemetryReporter.TELEMETRY_CONFIG_ID);
+        if (this.userOptIn !== config.get<boolean>(TelemetryReporter.TELEMETRY_CONFIG_ENABLED_ID, true)) {
+            this.userOptIn = config.get<boolean>(TelemetryReporter.TELEMETRY_CONFIG_ENABLED_ID, true);
+            if (this.userOptIn) {
+                this.createAppInsightsClient(key);
+            } else {
+                this.dispose();
+            }
+        }
+    }
+
+    private createAppInsightsClient(key: string) {
+        //check if another instance is already initialized
+        if (appInsights.defaultClient) {
+            this.appInsightsClient = new appInsights.TelemetryClient(key);
+            // no other way to enable offline mode
+            this.appInsightsClient.channel.setUseDiskRetryCaching(true);
+        } else {
+            appInsights.setup(key)
+                .setAutoCollectRequests(false)
+                .setAutoCollectPerformance(false)
+                .setAutoCollectExceptions(false)
+                .setAutoCollectDependencies(false)
+                .setAutoDependencyCorrelation(false)
+                .setAutoCollectConsole(false)
+                .setUseDiskRetryCaching(true)
+                .start();
+            this.appInsightsClient = appInsights.defaultClient;
+        }
+
+        this.appInsightsClient.commonProperties = this.getCommonProperties();
+        if (vscode && vscode.env) {
+            this.appInsightsClient.context.tags[this.appInsightsClient.context.keys.userId] = vscode.env.machineId;
+            this.appInsightsClient.context.tags[this.appInsightsClient.context.keys.sessionId] = vscode.env.sessionId;
+        }
+        //check if it's an Asimov key to change the endpoint
+        if (key && key.indexOf('AIF-') === 0) {
+            this.appInsightsClient.config.endpointUrl = "https://vortex.data.microsoft.com/collect/v1";
+        }
+    }
+
+    // __GDPR__COMMON__ "common.os" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+    // __GDPR__COMMON__ "common.platformversion" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+    // __GDPR__COMMON__ "common.extname" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" }
+    // __GDPR__COMMON__ "common.extversion" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" }
+    // __GDPR__COMMON__ "common.vscodemachineid" : { "endPoint": "MacAddressHash", "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
+    // __GDPR__COMMON__ "common.vscodesessionid" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+    // __GDPR__COMMON__ "common.vscodeversion" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+    private getCommonProperties(): { [key: string]: string } {
+        const commonProperties = Object.create(null);
+        commonProperties['common.os'] = os.platform();
+        commonProperties['common.platformversion'] = (os.release() || '').replace(/^(\d+)(\.\d+)?(\.\d+)?(.*)/, '$1$2$3');
+        commonProperties['common.extname'] = this.extensionId;
+        commonProperties['common.extversion'] = this.extensionVersion;
+        if (vscode && vscode.env) {
+            commonProperties['common.vscodemachineid'] = vscode.env.machineId;
+            commonProperties['common.vscodesessionid'] = vscode.env.sessionId;
+            commonProperties['common.vscodeversion'] = vscode.version;
+        }
+        return {
+            ...commonProperties,
+            ...this.customCommonProperties
+        };
+    }
+
+    public setCommonProperty(properties: { [key: string]: string }) {
+        this.customCommonProperties = {
+            ...this.customCommonProperties,
+            ...properties
+        };
+        this.appInsightsClient.commonProperties = {
+            ...this.appInsightsClient.commonProperties,
+            ...properties
+        };
+    }
+
+    public sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measurements?: { [key: string]: number }): void {
+        if (this.userOptIn && eventName && this.appInsightsClient) {
+            this.appInsightsClient.trackEvent({
+                name: `${this.extensionId}/${eventName}`,
+                properties: properties,
+                measurements: measurements
+            })
+
+            if (this.logStream) {
+                this.logStream.write(`telemetry/${eventName} ${JSON.stringify({ properties, measurements })}\n`);
+            }
+        }
+    }
+
+    public sendTelemetryMetric(
+        metricName: string,
+        value: number,
+        properties?: { [key: string]: string },
+        count?: number,
+        min?: number,
+        max?: number,
+        stdDev?: number,
+    ): void {
+        if (this.userOptIn && metricName && this.appInsightsClient) {
+            this.appInsightsClient.trackMetric({
+                name: `${this.extensionId}/${metricName}`,
+                value: value,
+                properties: properties,
+                count: count,
+                min: min,
+                max: max,
+                stdDev: stdDev
+            });
+
+            if (this.logStream) {
+                this.logStream.write(`telemetry/${metricName} ${value} ${JSON.stringify({ properties, count, min, max, stdDev })}\n`);
+            }
+        }
+    }
+
+    public sendTelemetryException(error: Error, properties?: { [key: string]: string }, measurements?: { [key: string]: number }): void {
+        if (this.userOptIn && error && this.appInsightsClient) {
+            this.appInsightsClient.trackException({
+                exception: error,
+                properties: properties,
+                measurements: measurements
+            })
+
+            if (this.logStream) {
+                this.logStream.write(`telemetry/${error.name} ${error.message} ${JSON.stringify({ properties, measurements })}\n`);
+            }
+        }
+    }
+
+    public dispose(): Promise<any> {
+
+        this.configListener.dispose();
+
+        const flushEventsToLogger = new Promise<any>(resolve => {
+            if (!this.logStream) {
+                return resolve(void 0);
+            }
+            this.logStream.on('finish', resolve);
+            this.logStream.end();
+        });
+
+        const flushEventsToAI = new Promise<any>(resolve => {
+            if (this.appInsightsClient) {
+                this.appInsightsClient.flush({
+                    callback: () => {
+                        // all data flushed
+                        this.appInsightsClient = undefined;
+                        resolve(void 0);
+                    }
+                });
+            } else {
+                resolve(void 0);
+            }
+        });
+        return Promise.all([flushEventsToAI, flushEventsToLogger]);
+    }
+}

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -11,9 +11,8 @@ import vscode from 'vscode';
 import * as appInsights from 'applicationinsights';
 
 export default class TelemetryReporter {
-    public userOptIn: boolean = false;
-
     private appInsightsClient: appInsights.TelemetryClient | undefined;
+    private userOptIn: boolean = false;
     private readonly configListener: vscode.Disposable;
 
     private static TELEMETRY_CONFIG_ID = 'telemetry';
@@ -99,6 +98,10 @@ export default class TelemetryReporter {
             ...commonProperties,
             ...this.customCommonProperties
         };
+    }
+
+    public getUserOptIn() {
+        return this.userOptIn;
     }
 
     public setCommonProperty(properties: { [key: string]: string }) {

--- a/test/unitTests/observers/telemetryObserver.test.ts
+++ b/test/unitTests/observers/telemetryObserver.test.ts
@@ -1,12 +1,12 @@
 import assert from 'assert';
 import { UserSignInTriggered, UserSignInSucceeded, UserSignInFailed, UserSignOutTriggered, UserSignOutSucceeded, UserSignOutFailed, BuildCanceled, BuildFailed, BuildTriggered, BuildSucceeded, LearnMoreClicked, QuickPickTriggered, QuickPickCommandSelected, DependencyInstallStarted, DependencyInstallCompleted, PackageInstallCompleted, BuildCacheSizeCalculated, } from '../../../src/common/loggingEvents';
 import { TelemetryObserver } from '../../../src/observers/telemetryObserver';
-import TelemetryReporter from 'vscode-extension-telemetry';
 import { DocsError } from '../../../src/error/docsError';
 import { ErrorCode } from '../../../src/error/errorCode';
 import { BuildInput } from '../../../src/build/buildInput';
 import { BuildResult } from '../../../src/build/buildResult';
 import { fakedPackage, fakedCredential } from '../../utils/faker';
+import TelemetryReporter from '../../../src/telemetryReporter';
 
 describe('TelemetryObserver', () => {
     let observer: TelemetryObserver;


### PR DESCRIPTION
import source code from vscode-extension-telemetry with the following changes:
- expose `userOptIn` which will be used to decide whether need to send telemetry in docfx
- support set custom common property
- support `sendTelemetryMetric`