### PR TITLE
Release 0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.1.22 (September 2, 2020)
+### Added
+- Support validating learn repository. (#115)
+- Support debug mode. (#120)
+### Changed
+- Use latest docfx: 3.0.0-beta1.353+50b0b3e0b1. (#121)
+
 ## 0.1.21 (August 24, 2020)
 ### Added
 - Support validating paired repository linked to a provisioned repository. (#115)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-build",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "docs-build",
   "displayName": "docs-validation",
   "description": "Docs Validation Extension",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "engines": {
     "vscode": "^1.40.0"
   },


### PR DESCRIPTION
## 0.1.22 (September 2, 2020)
### Added
- Support validating learn repository. (#115)
- Support debug mode. (#120)
### Changed
- Use latest docfx: 3.0.0-beta1.353+50b0b3e0b1. (#121)