### PR TITLE
Update UX to let contributor to trigger build without sign-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "commands": [
       {
         "command": "docs.signIn",
-        "title": "Sign in to Docs",
+        "title": "Sign in to Docs (!This is only available for Microsoft internal user)",
         "category": "Docs"
       },
       {
@@ -72,7 +72,7 @@
       },
       {
         "command": "docs.build",
-        "title": "Validate this workspace folder",
+        "title": "Validate this repository",
         "category": "Docs"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,6 +157,7 @@ function createQuickPickMenu(correlationId: string, eventStream: EventStream, cr
             });
     }
 
+    quickPickMenu.placeholder = "Which command would you like to run?";
     quickPickMenu.items = pickItems;
     quickPickMenu.onDidChangeSelection(selection => {
         if (selection[0]) {

--- a/src/observers/docsStatusBarObserver.ts
+++ b/src/observers/docsStatusBarObserver.ts
@@ -5,7 +5,7 @@ import { Credential } from '../credential/credentialController';
 import { StatusBarItem } from 'vscode';
 import { EnvironmentController } from '../common/environmentController';
 
-export class SignStatusBarObserver extends BaseStatusBarObserver {
+export class DocsStatusBarObserver extends BaseStatusBarObserver {
     constructor(statusBarItem: StatusBarItem, private _environmentController: EnvironmentController) {
         super(statusBarItem);
     }
@@ -13,29 +13,33 @@ export class SignStatusBarObserver extends BaseStatusBarObserver {
     public eventHandler = (event: BaseEvent) => {
         switch (event.type) {
             case EventType.CredentialInitializing:
-                this.setAndShowStatusBar(`${this.statusBarTextPrefix} Initializing`, undefined);
+                this.setDocsStatusBar(`Initializing`);
                 break;
             case EventType.UserSignInTriggered:
-                this.setAndShowStatusBar(`${this.statusBarTextPrefix} Signing in`, undefined);
+                this.setDocsStatusBar(`Signing in`, 'docs.signOut');
                 break;
             case EventType.UserSignInCompleted:
                 if ((<UserSignInCompleted>event).succeeded) {
-                    let asUserSignInSucceeded = <UserSignInSucceeded> event;
+                    let asUserSignInSucceeded = <UserSignInSucceeded>event;
                     this.handleSignedIn(asUserSignInSucceeded.credential);
                 }
                 break;
             case EventType.CredentialReset:
-                this.setAndShowStatusBar(`${this.statusBarTextPrefix} Sign in to Docs`, 'docs.signIn');
+                this.setDocsStatusBar(undefined, 'docs.validationQuickPick');
                 break;
         }
     }
 
     private get statusBarTextPrefix() {
-        return this._environmentController.env === 'PPE' ? 'Docs Validation(PPE):' : 'Docs Validation:';
+        return this._environmentController.env === 'PPE' ? 'Docs Validation(PPE)' : 'Docs Validation';
     }
 
     private handleSignedIn(credential: Credential) {
         let icon = credential.userInfo!.signType === 'GitHub' ? '$(mark-github)' : '$(rocket)';
-        this.setAndShowStatusBar(`${this.statusBarTextPrefix} ${icon} ${credential.userInfo!.userName}`, 'docs.validationQuickPick');
+        this.setDocsStatusBar(`${icon} ${credential.userInfo!.userName}`, 'docs.validationQuickPick');
+    }
+
+    private setDocsStatusBar(content?: string, command?: string) {
+        this.setAndShowStatusBar(`$(play) ${this.statusBarTextPrefix}${content ? (": " + content) : ''}`, command, undefined, 'Show quick pick(Alt + D)');
     }
 }

--- a/test/unitTests/observers/docsStatusBarObserver.test.ts
+++ b/test/unitTests/observers/docsStatusBarObserver.test.ts
@@ -1,14 +1,14 @@
 import assert from 'assert';
-import { SignStatusBarObserver } from '../../../src/observers/signStatusBarObserver';
+import { DocsStatusBarObserver } from '../../../src/observers/docsStatusBarObserver';
 import { StatusBarItem } from 'vscode';
 import { CredentialInitializing, UserSignInSucceeded, CredentialReset, UserSignInTriggered } from '../../../src/common/loggingEvents';
 import { getFakeEnvironmentController, setEnvToPPE, fakedCredential } from '../../utils/faker';
 import { EnvironmentController } from '../../../src/common/environmentController';
 
-describe('SignStatusBarObserver', () => {
+describe('DocsStatusBarObserver', () => {
     let showCalled: boolean;
     let environmentController: EnvironmentController;
-    let observer: SignStatusBarObserver;
+    let observer: DocsStatusBarObserver;
 
     let statusBarItem = <StatusBarItem>{
         show: () => { showCalled = true; }
@@ -16,7 +16,7 @@ describe('SignStatusBarObserver', () => {
 
     before(() => {
         environmentController = getFakeEnvironmentController();
-        observer = new SignStatusBarObserver(statusBarItem, environmentController);
+        observer = new DocsStatusBarObserver(statusBarItem, environmentController);
     });
 
     beforeEach(() => {
@@ -30,36 +30,36 @@ describe('SignStatusBarObserver', () => {
         let event = new CredentialInitializing();
         observer.eventHandler(event);
         assert.equal(showCalled, true);
-        assert.equal(statusBarItem.text, `Docs Validation: Initializing`);
+        assert.equal(statusBarItem.text, `$(play) Docs Validation: Initializing`);
         assert.equal(statusBarItem.command, undefined);
-        assert.equal(statusBarItem.tooltip, undefined);
+        assert.equal(statusBarItem.tooltip, 'Show quick pick(Alt + D)');
     });
 
     it(`User Signing in: Status bar is shown with 'Signing In' text`, () => {
         let event = new UserSignInTriggered('FakedCorrelationId');
         observer.eventHandler(event);
         assert.equal(showCalled, true);
-        assert.equal(statusBarItem.text, `Docs Validation: Signing in`);
-        assert.equal(statusBarItem.command, undefined);
-        assert.equal(statusBarItem.tooltip, undefined);
+        assert.equal(statusBarItem.text, `$(play) Docs Validation: Signing in`);
+        assert.equal(statusBarItem.command, 'docs.signOut');
+        assert.equal(statusBarItem.tooltip, 'Show quick pick(Alt + D)');
     });
 
     it(`User Signed In: Status bar is shown with user info`, () => {
         let event = new UserSignInSucceeded('FakedCorrelationId', fakedCredential);
         observer.eventHandler(event);
         assert.equal(showCalled, true);
-        assert.equal(statusBarItem.text, `Docs Validation: $(mark-github) Faked User`);
+        assert.equal(statusBarItem.text, `$(play) Docs Validation: $(mark-github) Faked User`);
         assert.equal(statusBarItem.command, 'docs.validationQuickPick');
-        assert.equal(statusBarItem.tooltip, undefined);
+        assert.equal(statusBarItem.tooltip, 'Show quick pick(Alt + D)');
     });
 
     it(`Reset User Info: Status bar is shown with 'Sign-in to Docs' text`, () => {
         let event = new CredentialReset();
         observer.eventHandler(event);
         assert.equal(showCalled, true);
-        assert.equal(statusBarItem.text, `Docs Validation: Sign in to Docs`);
-        assert.equal(statusBarItem.command, 'docs.signIn');
-        assert.equal(statusBarItem.tooltip, undefined);
+        assert.equal(statusBarItem.text, `$(play) Docs Validation`);
+        assert.equal(statusBarItem.command, 'docs.validationQuickPick');
+        assert.equal(statusBarItem.tooltip, 'Show quick pick(Alt + D)');
     });
 
     it(`PPE Environment: Status bar is shown with 'Docs (PPE):'`, () => {
@@ -70,8 +70,8 @@ describe('SignStatusBarObserver', () => {
         let event = new CredentialInitializing();
         observer.eventHandler(event);
         assert.equal(showCalled, true);
-        assert.equal(statusBarItem.text, `Docs Validation(PPE): Initializing`);
+        assert.equal(statusBarItem.text, `$(play) Docs Validation(PPE): Initializing`);
         assert.equal(statusBarItem.command, undefined);
-        assert.equal(statusBarItem.tooltip, undefined);
+        assert.equal(statusBarItem.tooltip, 'Show quick pick(Alt + D)');
     });
 });


### PR DESCRIPTION
[AB#288444](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/288444)

# StatusBar:
- If the user signed-in
![image](https://user-images.githubusercontent.com/17958546/93576609-a7f9cf80-f9cd-11ea-9986-4c87900dae1f.png)
- During the user signing in
![image](https://user-images.githubusercontent.com/17958546/93577264-69184980-f9ce-11ea-9a56-3c355828e80a.png)
- If the user hasn't signed-in
![image](https://user-images.githubusercontent.com/17958546/93577212-5a319700-f9ce-11ea-840b-9234eed0c8d9.png)


# Quick Pick menu
- If the user hasn't signed-in
![image](https://user-images.githubusercontent.com/17958546/93577600-d035fe00-f9ce-11ea-91c3-92af127836a2.png)

- If the user signed-in
![image](https://user-images.githubusercontent.com/17958546/93577760-06737d80-f9cf-11ea-86ed-9d06783d8fa1.png)

- If the validation is running
![image](https://user-images.githubusercontent.com/17958546/93577791-10957c00-f9cf-11ea-8ff4-6d7123f583e2.png)

@meganbradley @herohua Please help to review this PR which contains some UX change on the Docs Validation extension.
Please note this PR doesn't contain the changes required on the quick-pick menu of `docs-markdown`, that would be a separated one.

