### PR TITLE
Handle `PullRequestOnly` diagnostics

### DIFF
--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -35,9 +35,10 @@ $ code .
 
 1. Set a breakpoint.
 2. Set `VSCODE_DOCS_BUILD_EXTENSION_BUILD_USER_TOKEN` in [launch.json](../.vscode/launch.json)
-3. Select `Launch extension e2e tests` in the `Run and Debug` Tab.
-4. Press `F5` to run the extension
-5. Check the `Variables`, `Call Stack` and use the `Watch` in the `Run and Debug` Tab.
+3. Run `git submodule update --init` in terminal.
+4. Select `Launch extension e2e tests` in the `Run and Debug` Tab.
+5. Press `F5` to run the extension
+6. Check the `Variables`, `Call Stack` and use the `Watch` in the `Run and Debug` Tab.
 
 ### Debug the UT
 

--- a/src/build/reportGenerator.ts
+++ b/src/build/reportGenerator.ts
@@ -19,6 +19,7 @@ interface ReportItem {
     column: number;
     end_column: number;
     date_time: Date;
+    pull_request_only: boolean;
 }
 
 const severityMap = new Map<MessageSeverity, vscode.DiagnosticSeverity>([
@@ -49,6 +50,10 @@ export function visualizeBuildReport(repositoryPath: string, logPath: string, di
             if (!reportItem.file) {
                 return;
             }
+            if (reportItem.pull_request_only) {
+                return;
+            }
+
             let range = new vscode.Range(
                 convertToZeroBased(reportItem.line),
                 convertToZeroBased(reportItem.column),

--- a/test/unitTests/build/reportGenerator.test.ts
+++ b/test/unitTests/build/reportGenerator.test.ts
@@ -15,7 +15,9 @@ describe("ReportGenerator", () => {
     const testLogPath = path.resolve(__dirname, ".errors.log");
     const fakedErrorLog = `{"message_severity":"info","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`
         + `{"message_severity":"warning","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`
-        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`;
+        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`
+        // expected behavior after adding this new item: do nothing since it will be skipped with "pull_request_only": true
+        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":true}\n`;
 
     let eventStream: EventStream;
     let testEventBus: TestEventBus;

--- a/test/unitTests/build/reportGenerator.test.ts
+++ b/test/unitTests/build/reportGenerator.test.ts
@@ -120,7 +120,7 @@ describe("ReportGenerator", () => {
             new BuildProgress(`Log file found, Generating report...`),
         ]);
     });
-    it("Report with pull request messages found", () => {
+    it("Handle pull_request_only diagnostics", () => {
         const fakedErrorLogWithPullRequest =  `{"message_severity":"warning","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":true}\n`
             + `{"message_severity":"info","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":false}\n`
             + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":null}\n`;
@@ -130,7 +130,6 @@ describe("ReportGenerator", () => {
             .withArgs(path.normalize(testLogPath)).returns(fakedErrorLogWithPullRequest);
 
         visualizeBuildReport(testRepositoryPath, testLogPath, fakedDiagnosticController, eventStream);
-        // Expected behavior: only the first message with true pull request will be skipped, therefore the second and the third message will show up in the diagnostic set.
         assert.deepStrictEqual(diagnosticSet, {
             [path.normalize(`${testRepositoryPath}/index.md`)]: {
                 uri: expectedFileUri,

--- a/test/unitTests/build/reportGenerator.test.ts
+++ b/test/unitTests/build/reportGenerator.test.ts
@@ -19,7 +19,7 @@ describe("ReportGenerator", () => {
         // Expected behavior after adding this new item: do nothing since it will be skipped when pull_request_only is true
         + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":true}\n`
         // Expected behavior after adding this new item: add it to the diagnostic channel since we only skip it when pull_request_only is true
-        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":false}\n`;
+        + `{"message_severity":"warning","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":false}\n`;
 
     let eventStream: EventStream;
     let testEventBus: TestEventBus;
@@ -118,7 +118,7 @@ describe("ReportGenerator", () => {
                     expectedInfoDiagnostic,
                     expectedWarningDiagnostic,
                     expectedErrorDiagnostic,
-                    expectedErrorDiagnostic
+                    expectedWarningDiagnostic
                 ]
             },
         });

--- a/test/unitTests/build/reportGenerator.test.ts
+++ b/test/unitTests/build/reportGenerator.test.ts
@@ -16,8 +16,10 @@ describe("ReportGenerator", () => {
     const fakedErrorLog = `{"message_severity":"info","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`
         + `{"message_severity":"warning","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`
         + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`
-        // expected behavior after adding this new item: do nothing since it will be skipped with "pull_request_only": true
-        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":true}\n`;
+        // Expected behavior after adding this new item: do nothing since it will be skipped when pull_request_only is true
+        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":true}\n`
+        // Expected behavior after adding this new item: add it to the diagnostic channel since we only skip it when pull_request_only is true
+        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":false}\n`;
 
     let eventStream: EventStream;
     let testEventBus: TestEventBus;
@@ -115,6 +117,7 @@ describe("ReportGenerator", () => {
                 diagnostics: [
                     expectedInfoDiagnostic,
                     expectedWarningDiagnostic,
+                    expectedErrorDiagnostic,
                     expectedErrorDiagnostic
                 ]
             },

--- a/test/unitTests/build/reportGenerator.test.ts
+++ b/test/unitTests/build/reportGenerator.test.ts
@@ -15,12 +15,9 @@ describe("ReportGenerator", () => {
     const testLogPath = path.resolve(__dirname, ".errors.log");
     const fakedErrorLog = `{"message_severity":"info","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`
         + `{"message_severity":"warning","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`
-        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`
-        // Expected behavior after adding this new item: do nothing since it will be skipped when pull_request_only is true
-        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":true}\n`
-        // Expected behavior after adding this new item: add it to the diagnostic channel since we only skip it when pull_request_only is true
-        + `{"message_severity":"warning","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":false}\n`;
-
+        + `{"message_severity":"error","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z"}\n`;
+    const fakedErrorLogWithTruePullRequest =  `{"message_severity":"warning","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":true}\n`;
+    const fakedErrorLogWithFalsePullRequest =  `{"message_severity":"warning","log_item_type":"user","code":"author-missing","message":"Missing required attribute: 'author'. Add the current author's GitHub ID.","file":"index.md","line":1,"end_line":1,"column":1,"end_column":1,"date_time":"2020-03-04T08:43:12.3284386Z", "pull_request_only":false}\n`;
     let eventStream: EventStream;
     let testEventBus: TestEventBus;
 
@@ -117,7 +114,39 @@ describe("ReportGenerator", () => {
                 diagnostics: [
                     expectedInfoDiagnostic,
                     expectedWarningDiagnostic,
-                    expectedErrorDiagnostic,
+                    expectedErrorDiagnostic
+                ]
+            },
+        });
+        assert.deepStrictEqual(testEventBus.getEvents(), [
+            new BuildProgress(`Log file found, Generating report...`),
+        ]);
+    });
+    it("Report with true pull request message found", () => {
+        stubFsExistsSync
+            .withArgs(path.normalize(testLogPath)).returns(true);
+        stubFsReadFileSync
+            .withArgs(path.normalize(testLogPath)).returns(fakedErrorLogWithTruePullRequest);
+
+        visualizeBuildReport(testRepositoryPath, testLogPath, fakedDiagnosticController, eventStream);
+        // Expected behavior: the diagnositic set should be empty, since the messages with true pull request will be skipped.
+        assert.deepStrictEqual(diagnosticSet, {});
+        assert.deepStrictEqual(testEventBus.getEvents(), [
+            new BuildProgress(`Log file found, Generating report...`),
+        ]);
+    });
+    it("Report with false pull request message found", () => {
+        stubFsExistsSync
+            .withArgs(path.normalize(testLogPath)).returns(true);
+        stubFsReadFileSync
+            .withArgs(path.normalize(testLogPath)).returns(fakedErrorLogWithFalsePullRequest);
+
+        visualizeBuildReport(testRepositoryPath, testLogPath, fakedDiagnosticController, eventStream);
+        // Expected behavior: the message will show up since only the messages with true pull request will be skipped.
+        assert.deepStrictEqual(diagnosticSet, {
+            [path.normalize(`${testRepositoryPath}/index.md`)]: {
+                uri: expectedFileUri,
+                diagnostics: [
                     expectedWarningDiagnostic
                 ]
             },


### PR DESCRIPTION
**Story Link**: [AB#335560](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/335560)

**Description**
Hide all build messages from Docfx with 'pull_request_only: true' during local validation.

**Testing**
 Add two test cases when 'pull_request_only' is set to true/ false, the result is as expected that only the case with 'pull_request_only: true' is skipped, so that we won't see the message in the diagnostic channel.

Message schema from errors.log: {"message_severity":"suggestion","code":"description-missing","message":"Missing required attribute: 'description'.","file":"microsoft-edge/hosting/javascript-runtime-hosting.md","line":2,"end_line":2,"column":1,"end_column":1,"log_item_type":"user"**,"pull_request_only":true**,"property_path":"description","date_time":"2020-11-13T08:35:45.1124345Z"}