### PR TITLE
User should explicitly choose their role (Microsoft employee / public contributor)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
             "Public Contributor"
           ],
           "default": "",
-          "description": "Microsoft internal employee or public constructor"
+          "description": "Microsoft internal employee or public contributor"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
         "docs-build.userType": {
           "type": "string",
           "enum": [
-            "undefined",
-            "internal",
-            "public"
+            "",
+            "Microsoft Internal Employee",
+            "Public Contributor"
           ],
-          "default": "undefined",
+          "default": "",
           "description": "Microsoft internal employee or public constructor"
         }
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,16 @@
           "type": "boolean",
           "default": true,
           "description": "Show hint message to recommend Microsoft employee to sign in"
+        },
+        "docs-build.userType": {
+          "type": "string",
+          "enum": [
+            "undefined",
+            "internal",
+            "public"
+          ],
+          "default": "undefined",
+          "description": "Microsoft internal employee or public constructor"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,24 +60,24 @@
         "docs-build.hint.signRecommend": {
           "type": "boolean",
           "default": true,
-          "description": "Show hint message to recommend Microsoft internal employees to sign in"
+          "description": "Show hint message to recommend Microsoft employees to sign in"
         },
         "docs-build.userType": {
           "type": "string",
           "enum": [
             "",
-            "Microsoft Internal Employee",
+            "Microsoft Employee",
             "Public Contributor"
           ],
           "default": "",
-          "description": "Microsoft internal employee or public contributor"
+          "description": "Microsoft employee or public contributor"
         }
       }
     },
     "commands": [
       {
         "command": "docs.signIn",
-        "title": "Sign in to Docs (!This is only available for Microsoft internal employee)",
+        "title": "Sign in to Docs (!This is only available for Microsoft employee)",
         "category": "Docs"
       },
       {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "docs-build.hint.signRecommend": {
           "type": "boolean",
           "default": true,
-          "description": "Show hint message to recommend Microsoft employee to sign in"
+          "description": "Show hint message to recommend Microsoft internal employees to sign in"
         },
         "docs-build.userType": {
           "type": "string",
@@ -77,7 +77,7 @@
     "commands": [
       {
         "command": "docs.signIn",
-        "title": "Sign in to Docs (!This is only available for Microsoft internal user)",
+        "title": "Sign in to Docs (!This is only available for Microsoft internal employee)",
         "category": "Docs"
       },
       {

--- a/src/build/buildController.ts
+++ b/src/build/buildController.ts
@@ -14,7 +14,7 @@ import { DocsError } from '../error/docsError';
 import { ErrorCode } from '../error/errorCode';
 import { BuildInput, BuildType } from './buildInput';
 import { DocfxExecutionResult } from './buildResult';
-import { EnvironmentController } from '../common/environmentController';
+import { EnvironmentController, UserType } from '../common/environmentController';
 
 export class BuildController {
     private _currentBuildCorrelationId: string;
@@ -111,12 +111,12 @@ export class BuildController {
     }
 
     private async validateUserCredential(credential: Credential) {
-        if (this._environmentController.userType === "undefined") {
+        if (this._environmentController.userType === UserType.Unknow) {
             this._eventStream.post(new CheckIfInternal());
             throw new DocsError(`Validation needs user type provided, make a choice first`, ErrorCode.UndefinedUserBuild);
         }
         if (credential.signInStatus !== 'SignedIn') {
-            if (this._environmentController.userType === "internal") {
+            if (this._environmentController.userType === UserType.InternalEmployee) {
                 throw new DocsError(`Please sign in first`, ErrorCode.SignedOutInternalUserBuild);
             }
             return;

--- a/src/build/buildController.ts
+++ b/src/build/buildController.ts
@@ -115,7 +115,7 @@ export class BuildController {
             return;
         }
         if (credential.signInStatus !== 'SignedIn' && this._environmentController.userType === UserType.InternalEmployee) {
-            throw new DocsError(`Please sign in first`, ErrorCode.SignedOutInternalUserBuild);   
+            throw new DocsError(`Please sign in first`, ErrorCode.TriggerBuildBeforeSignIn);
         }
 
         if (!(await this._opBuildAPIClient.validateCredential(credential.userInfo.userToken, this._eventStream))) {

--- a/src/build/buildController.ts
+++ b/src/build/buildController.ts
@@ -114,8 +114,8 @@ export class BuildController {
         if (this._environmentController.userType === UserType.PublicContributor) {
             return;
         }
-        if (credential.signInStatus !== 'SignedIn' && this._environmentController.userType === UserType.InternalEmployee) {
-            throw new DocsError(`It is required for internal employees to sign in before validation, please sign in first.`, ErrorCode.TriggerBuildBeforeSignIn);
+        if (credential.signInStatus !== 'SignedIn' && this._environmentController.userType === UserType.MicrosoftInternalEmployee) {
+            throw new DocsError(`It is required for Microsoft internal employees to sign in before validation, please sign in first.`, ErrorCode.TriggerBuildBeforeSignIn);
         }
 
         if (!(await this._opBuildAPIClient.validateCredential(credential.userInfo.userToken, this._eventStream))) {

--- a/src/build/buildController.ts
+++ b/src/build/buildController.ts
@@ -114,8 +114,8 @@ export class BuildController {
         if (this._environmentController.userType === UserType.PublicContributor) {
             return;
         }
-        if (credential.signInStatus !== 'SignedIn' && this._environmentController.userType === UserType.MicrosoftInternalEmployee) {
-            throw new DocsError(`It is required for Microsoft internal employees to sign in before validation, please sign in first.`, ErrorCode.TriggerBuildBeforeSignIn);
+        if (credential.signInStatus !== 'SignedIn' && this._environmentController.userType === UserType.MicrosoftEmployee) {
+            throw new DocsError(`Microsoft employees must sign in before validating.`, ErrorCode.TriggerBuildBeforeSignIn);
         }
 
         if (!(await this._opBuildAPIClient.validateCredential(credential.userInfo.userToken, this._eventStream))) {

--- a/src/build/buildController.ts
+++ b/src/build/buildController.ts
@@ -111,11 +111,11 @@ export class BuildController {
     }
 
     private async validateUserCredential(credential: Credential) {
-        if (credential.signInStatus !== 'SignedIn') {
-            if (this._environmentController.userType === UserType.InternalEmployee) {
-                throw new DocsError(`Please sign in first`, ErrorCode.SignedOutInternalUserBuild);
-            }
+        if (this._environmentController.userType === UserType.PublicContributor) {
             return;
+        }
+        if (credential.signInStatus !== 'SignedIn' && this._environmentController.userType === UserType.InternalEmployee) {
+            throw new DocsError(`Please sign in first`, ErrorCode.SignedOutInternalUserBuild);   
         }
 
         if (!(await this._opBuildAPIClient.validateCredential(credential.userInfo.userToken, this._eventStream))) {

--- a/src/build/buildController.ts
+++ b/src/build/buildController.ts
@@ -115,7 +115,7 @@ export class BuildController {
             return;
         }
         if (credential.signInStatus !== 'SignedIn' && this._environmentController.userType === UserType.InternalEmployee) {
-            throw new DocsError(`Please sign in first`, ErrorCode.TriggerBuildBeforeSignIn);
+            throw new DocsError(`It is required for internal employees to sign in before validation, please sign in first.`, ErrorCode.TriggerBuildBeforeSignIn);
         }
 
         if (!(await this._opBuildAPIClient.validateCredential(credential.userInfo.userToken, this._eventStream))) {

--- a/src/build/buildController.ts
+++ b/src/build/buildController.ts
@@ -9,7 +9,7 @@ import { safelyReadJsonFile, getRepositoryInfoFromLocalFolder, getDurationInSeco
 import { BuildExecutor } from './buildExecutor';
 import { OP_CONFIG_FILE_NAME } from '../shared';
 import { visualizeBuildReport } from './reportGenerator';
-import { BuildInstantAllocated, BuildInstantReleased, BuildProgress, RepositoryInfoRetrieved, BuildTriggered, BuildFailed, BuildStarted, BuildSucceeded, BuildCanceled, CancelBuildTriggered, CancelBuildSucceeded, CancelBuildFailed, CredentialExpired } from '../common/loggingEvents';
+import { BuildInstantAllocated, BuildInstantReleased, BuildProgress, RepositoryInfoRetrieved, BuildTriggered, BuildFailed, BuildStarted, BuildSucceeded, BuildCanceled, CancelBuildTriggered, CancelBuildSucceeded, CancelBuildFailed, CredentialExpired, CheckIfInternal } from '../common/loggingEvents';
 import { DocsError } from '../error/docsError';
 import { ErrorCode } from '../error/errorCode';
 import { BuildInput, BuildType } from './buildInput';
@@ -111,7 +111,14 @@ export class BuildController {
     }
 
     private async validateUserCredential(credential: Credential) {
+        if (this._environmentController.userType === "undefined") {
+            this._eventStream.post(new CheckIfInternal());
+            throw new DocsError(`Validation needs user type provided, make a choice first`, ErrorCode.UndefinedUserBuild);
+        }
         if (credential.signInStatus !== 'SignedIn') {
+            if (this._environmentController.userType === "internal") {
+                throw new DocsError(`Please sign in first`, ErrorCode.SignedOutInternalUserBuild);
+            }
             return;
         }
 

--- a/src/build/buildController.ts
+++ b/src/build/buildController.ts
@@ -7,14 +7,14 @@ import { EventStream } from '../common/eventStream';
 import { DiagnosticController } from './diagnosticController';
 import { safelyReadJsonFile, getRepositoryInfoFromLocalFolder, getDurationInSeconds, normalizeDriveLetter, getTempOutputFolder } from '../utils/utils';
 import { BuildExecutor } from './buildExecutor';
-import { OP_CONFIG_FILE_NAME } from '../shared';
+import { OP_CONFIG_FILE_NAME, UserType } from '../shared';
 import { visualizeBuildReport } from './reportGenerator';
-import { BuildInstantAllocated, BuildInstantReleased, BuildProgress, RepositoryInfoRetrieved, BuildTriggered, BuildFailed, BuildStarted, BuildSucceeded, BuildCanceled, CancelBuildTriggered, CancelBuildSucceeded, CancelBuildFailed, CredentialExpired, CheckIfInternal } from '../common/loggingEvents';
+import { BuildInstantAllocated, BuildInstantReleased, BuildProgress, RepositoryInfoRetrieved, BuildTriggered, BuildFailed, BuildStarted, BuildSucceeded, BuildCanceled, CancelBuildTriggered, CancelBuildSucceeded, CancelBuildFailed, CredentialExpired } from '../common/loggingEvents';
 import { DocsError } from '../error/docsError';
 import { ErrorCode } from '../error/errorCode';
 import { BuildInput, BuildType } from './buildInput';
 import { DocfxExecutionResult } from './buildResult';
-import { EnvironmentController, UserType } from '../common/environmentController';
+import { EnvironmentController } from '../common/environmentController';
 
 export class BuildController {
     private _currentBuildCorrelationId: string;
@@ -111,10 +111,6 @@ export class BuildController {
     }
 
     private async validateUserCredential(credential: Credential) {
-        if (this._environmentController.userType === UserType.Unknow) {
-            this._eventStream.post(new CheckIfInternal());
-            throw new DocsError(`Validation needs user type provided, make a choice first`, ErrorCode.UndefinedUserBuild);
-        }
         if (credential.signInStatus !== 'SignedIn') {
             if (this._environmentController.userType === UserType.InternalEmployee) {
                 throw new DocsError(`Please sign in first`, ErrorCode.SignedOutInternalUserBuild);

--- a/src/common/docsEnvironmentController.ts
+++ b/src/common/docsEnvironmentController.ts
@@ -85,7 +85,7 @@ export class DocsEnvironmentController implements EnvironmentController, vscode.
 
     private getUserType(): UserType {
         const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-        return extensionConfig.get<UserType>(USER_TYPE, UserType.Unknow);
+        return extensionConfig.get<UserType>(USER_TYPE, UserType.Unknown);
     }
 
     private async getDocsRepoType(): Promise<DocsRepoType> {

--- a/src/common/docsEnvironmentController.ts
+++ b/src/common/docsEnvironmentController.ts
@@ -1,8 +1,8 @@
 import vscode from 'vscode';
-import { Environment, DocsRepoType, EXTENSION_NAME, ENVIRONMENT_CONFIG_NAME, DEBUG_MODE_CONFIG_NAME, SIGN_RECOMMEND_HINT_CONFIG_NAME, USER_TYPE } from '../shared';
+import { Environment, DocsRepoType, EXTENSION_NAME, ENVIRONMENT_CONFIG_NAME, DEBUG_MODE_CONFIG_NAME, SIGN_RECOMMEND_HINT_CONFIG_NAME, USER_TYPE, UserType } from '../shared';
 import { EnvironmentChanged } from './loggingEvents';
 import { EventStream } from './eventStream';
-import { EnvironmentController, UserType } from './environmentController';
+import { EnvironmentController } from './environmentController';
 import { getRepositoryInfoFromLocalFolder } from '../utils/utils';
 
 export class DocsEnvironmentController implements EnvironmentController, vscode.Disposable {

--- a/src/common/docsEnvironmentController.ts
+++ b/src/common/docsEnvironmentController.ts
@@ -2,7 +2,7 @@ import vscode from 'vscode';
 import { Environment, DocsRepoType, EXTENSION_NAME, ENVIRONMENT_CONFIG_NAME, DEBUG_MODE_CONFIG_NAME, SIGN_RECOMMEND_HINT_CONFIG_NAME, USER_TYPE } from '../shared';
 import { EnvironmentChanged } from './loggingEvents';
 import { EventStream } from './eventStream';
-import { EnvironmentController } from './environmentController';
+import { EnvironmentController, UserType } from './environmentController';
 import { getRepositoryInfoFromLocalFolder } from '../utils/utils';
 
 export class DocsEnvironmentController implements EnvironmentController, vscode.Disposable {
@@ -11,7 +11,7 @@ export class DocsEnvironmentController implements EnvironmentController, vscode.
     private _docsRepoType: DocsRepoType;
     private _configurationChangeListener: vscode.Disposable;
     private _enableSignRecommendHint: boolean;
-    private _userType: string;
+    private _userType: UserType;
 
     constructor(private _eventStream: EventStream) {
     }
@@ -64,7 +64,7 @@ export class DocsEnvironmentController implements EnvironmentController, vscode.
         return this._enableSignRecommendHint;
     }
 
-    public get userType(): string {
+    public get userType(): UserType {
         return this._userType;
     }
 
@@ -83,9 +83,9 @@ export class DocsEnvironmentController implements EnvironmentController, vscode.
         return extensionConfig.get<boolean>(SIGN_RECOMMEND_HINT_CONFIG_NAME, true);
     }
 
-    private getUserType(): string {
+    private getUserType(): UserType {
         const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-        return extensionConfig.get<string>(USER_TYPE, "undefined");
+        return extensionConfig.get<UserType>(USER_TYPE, UserType.Unknow);
     }
 
     private async getDocsRepoType(): Promise<DocsRepoType> {

--- a/src/common/docsEnvironmentController.ts
+++ b/src/common/docsEnvironmentController.ts
@@ -1,5 +1,5 @@
 import vscode from 'vscode';
-import { Environment, DocsRepoType, EXTENSION_NAME, ENVIRONMENT_CONFIG_NAME, DEBUG_MODE_CONFIG_NAME, SIGN_RECOMMEND_HINT_CONFIG_NAME } from '../shared';
+import { Environment, DocsRepoType, EXTENSION_NAME, ENVIRONMENT_CONFIG_NAME, DEBUG_MODE_CONFIG_NAME, SIGN_RECOMMEND_HINT_CONFIG_NAME, USER_TYPE } from '../shared';
 import { EnvironmentChanged } from './loggingEvents';
 import { EventStream } from './eventStream';
 import { EnvironmentController } from './environmentController';
@@ -11,6 +11,7 @@ export class DocsEnvironmentController implements EnvironmentController, vscode.
     private _docsRepoType: DocsRepoType;
     private _configurationChangeListener: vscode.Disposable;
     private _enableSignRecommendHint: boolean;
+    private _userType: string;
 
     constructor(private _eventStream: EventStream) {
     }
@@ -20,6 +21,7 @@ export class DocsEnvironmentController implements EnvironmentController, vscode.
         this._debugMode = this.getDebugMode();
         this._enableSignRecommendHint = this.getEnableSignRecommendHint();
         this._docsRepoType = await this.getDocsRepoType();
+        this._userType = this.getUserType();
 
         this._configurationChangeListener = vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
             if (event.affectsConfiguration(`${EXTENSION_NAME}.${ENVIRONMENT_CONFIG_NAME}`)) {
@@ -29,6 +31,8 @@ export class DocsEnvironmentController implements EnvironmentController, vscode.
                 this.reloadWindow();
             } else if (event.affectsConfiguration(`${EXTENSION_NAME}.${SIGN_RECOMMEND_HINT_CONFIG_NAME}`)) {
                 this._enableSignRecommendHint = this.getEnableSignRecommendHint();
+            } else if (event.affectsConfiguration(`${EXTENSION_NAME}.${USER_TYPE}`)) {
+                this._userType = this.getUserType();
             }
         });
     }
@@ -60,6 +64,10 @@ export class DocsEnvironmentController implements EnvironmentController, vscode.
         return this._enableSignRecommendHint;
     }
 
+    public get userType(): string {
+        return this._userType;
+    }
+
     private getEnv(): Environment {
         const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
         return extensionConfig.get<Environment>(ENVIRONMENT_CONFIG_NAME, 'PROD');
@@ -73,6 +81,11 @@ export class DocsEnvironmentController implements EnvironmentController, vscode.
     private getEnableSignRecommendHint(): boolean {
         const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
         return extensionConfig.get<boolean>(SIGN_RECOMMEND_HINT_CONFIG_NAME, true);
+    }
+
+    private getUserType(): string {
+        const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
+        return extensionConfig.get<string>(USER_TYPE, "undefined");
     }
 
     private async getDocsRepoType(): Promise<DocsRepoType> {

--- a/src/common/environmentController.ts
+++ b/src/common/environmentController.ts
@@ -5,4 +5,5 @@ export interface EnvironmentController {
     docsRepoType: DocsRepoType;
     debugMode: boolean;
     enableSignRecommendHint: boolean;
+    userType: string;
 }

--- a/src/common/environmentController.ts
+++ b/src/common/environmentController.ts
@@ -1,4 +1,4 @@
-import { Environment, DocsRepoType } from '../shared';
+import { Environment, DocsRepoType, UserType } from '../shared';
 
 export interface EnvironmentController {
     env: Environment;
@@ -6,11 +6,4 @@ export interface EnvironmentController {
     debugMode: boolean;
     enableSignRecommendHint: boolean;
     userType: UserType;
-}
-
-export enum UserType {
-    InternalEmployee = "Microsoft Internal Employee",
-    PublicContributor = "Public Contributor",
-    Unknow = ""
-
 }

--- a/src/common/environmentController.ts
+++ b/src/common/environmentController.ts
@@ -5,5 +5,12 @@ export interface EnvironmentController {
     docsRepoType: DocsRepoType;
     debugMode: boolean;
     enableSignRecommendHint: boolean;
-    userType: string;
+    userType: UserType;
+}
+
+export enum UserType {
+    InternalEmployee = "Microsoft Internal Employee",
+    PublicContributor = "Public Contributor",
+    Unknow = ""
+
 }

--- a/src/common/eventType.ts
+++ b/src/common/eventType.ts
@@ -8,8 +8,7 @@ export enum EventType {
     UserSignInCompleted,
     UserSignOutTriggered,
     UserSignOutCompleted,
-    PublicUserSignIn,
-    PublicUserSignOut,
+    PublicUserSign,
 
     // Build
     RepositoryInfoRetrieved,
@@ -52,7 +51,8 @@ export enum EventType {
     QuickPickTriggered,
     QuickPickCommandSelected,
     LearnMoreClicked,
-    CheckIfInternal,
+    TriggerCommandWithUnkownUserType,
+    ExtensionActivated,
 
     // Test only
     RefreshCredential,

--- a/src/common/eventType.ts
+++ b/src/common/eventType.ts
@@ -8,7 +8,7 @@ export enum EventType {
     UserSignInCompleted,
     UserSignOutTriggered,
     UserSignOutCompleted,
-    PublicUserSign,
+    PublicUserSignIn,
 
     // Build
     RepositoryInfoRetrieved,

--- a/src/common/eventType.ts
+++ b/src/common/eventType.ts
@@ -8,6 +8,8 @@ export enum EventType {
     UserSignInCompleted,
     UserSignOutTriggered,
     UserSignOutCompleted,
+    PublicUserSignIn,
+    PublicUserSignOut,
 
     // Build
     RepositoryInfoRetrieved,
@@ -50,6 +52,7 @@ export enum EventType {
     QuickPickTriggered,
     QuickPickCommandSelected,
     LearnMoreClicked,
+    CheckIfInternal,
 
     // Test only
     RefreshCredential,

--- a/src/common/extensionExport.ts
+++ b/src/common/extensionExport.ts
@@ -1,8 +1,10 @@
 import { EventStream } from "./eventStream";
 import { KeyChain } from "../credential/keyChain";
+import { EnvironmentController } from "./environmentController";
 
 export default interface ExtensionExports {
     initializationFinished: () => Promise<void>;
     eventStream: EventStream;
     keyChain: KeyChain;
+    environmentController: EnvironmentController;
 }

--- a/src/common/loggingEvents.ts
+++ b/src/common/loggingEvents.ts
@@ -82,7 +82,6 @@ export class PublicUserSignOut implements BaseEvent {
     constructor() { }
 }
 
-
 // Build
 export class RepositoryInfoRetrieved implements BaseEvent {
     type = EventType.RepositoryInfoRetrieved;

--- a/src/common/loggingEvents.ts
+++ b/src/common/loggingEvents.ts
@@ -1,7 +1,7 @@
 import { EventType } from './eventType';
 import { Credential } from '../credential/credentialController';
 import { PlatformInformation } from './platformInformation';
-import { Environment } from '../shared';
+import { Environment, SignAction } from '../shared';
 import { BuildResult, DocfxExecutionResult } from '../build/buildResult';
 import { BuildInput } from '../build/buildInput';
 import { AbsolutePathPackage } from '../dependency/package';
@@ -72,14 +72,9 @@ export class CredentialExpired implements BaseEvent {
     type = EventType.CredentialExpired;
 }
 
-export class PublicUserSignIn implements BaseEvent {
-    type = EventType.PublicUserSignIn;
-    constructor() { }
-}
-
-export class PublicUserSignOut implements BaseEvent {
-    type = EventType.PublicUserSignOut;
-    constructor() { }
+export class PublicUserSign implements BaseEvent {
+    type = EventType.PublicUserSign;
+    constructor(public action: SignAction) { }
 }
 
 // Build
@@ -255,8 +250,13 @@ export class LearnMoreClicked implements BaseEvent {
     constructor(public correlationId: string, public diagnosticErrorCode: string) { }
 }
 
-export class CheckIfInternal implements BaseEvent {
-    type = EventType.CheckIfInternal;
+export class TriggerCommandWithUnkownUserType implements BaseEvent {
+    type = EventType.TriggerCommandWithUnkownUserType;
+    constructor() { }
+}
+
+export class ExtensionActivated implements BaseEvent {
+    type = EventType.ExtensionActivated;
     constructor() { }
 }
 

--- a/src/common/loggingEvents.ts
+++ b/src/common/loggingEvents.ts
@@ -72,6 +72,17 @@ export class CredentialExpired implements BaseEvent {
     type = EventType.CredentialExpired;
 }
 
+export class PublicUserSignIn implements BaseEvent {
+    type = EventType.PublicUserSignIn;
+    constructor() { }
+}
+
+export class PublicUserSignOut implements BaseEvent {
+    type = EventType.PublicUserSignOut;
+    constructor() { }
+}
+
+
 // Build
 export class RepositoryInfoRetrieved implements BaseEvent {
     type = EventType.RepositoryInfoRetrieved;
@@ -243,6 +254,11 @@ export class QuickPickCommandSelected implements BaseEvent {
 export class LearnMoreClicked implements BaseEvent {
     type = EventType.LearnMoreClicked;
     constructor(public correlationId: string, public diagnosticErrorCode: string) { }
+}
+
+export class CheckIfInternal implements BaseEvent {
+    type = EventType.CheckIfInternal;
+    constructor() { }
 }
 
 // Test only

--- a/src/common/loggingEvents.ts
+++ b/src/common/loggingEvents.ts
@@ -1,7 +1,7 @@
 import { EventType } from './eventType';
 import { Credential } from '../credential/credentialController';
 import { PlatformInformation } from './platformInformation';
-import { Environment, SignAction } from '../shared';
+import { Environment } from '../shared';
 import { BuildResult, DocfxExecutionResult } from '../build/buildResult';
 import { BuildInput } from '../build/buildInput';
 import { AbsolutePathPackage } from '../dependency/package';
@@ -72,9 +72,9 @@ export class CredentialExpired implements BaseEvent {
     type = EventType.CredentialExpired;
 }
 
-export class PublicUserSign implements BaseEvent {
-    type = EventType.PublicUserSign;
-    constructor(public action: SignAction) { }
+export class PublicUserSignIn implements BaseEvent {
+    type = EventType.PublicUserSignIn;
+    constructor() { }
 }
 
 // Build
@@ -129,13 +129,13 @@ export class CancelBuildCompleted implements BaseEvent {
 }
 
 export class CancelBuildSucceeded extends CancelBuildCompleted {
-    constructor(public correlationId: string){
+    constructor(public correlationId: string) {
         super(correlationId, true);
     }
 }
 
 export class CancelBuildFailed extends CancelBuildCompleted {
-    constructor(public correlationId: string, public err?: Error){
+    constructor(public correlationId: string, public err?: Error) {
         super(correlationId, false);
     }
 }

--- a/src/credential/credentialController.ts
+++ b/src/credential/credentialController.ts
@@ -1,14 +1,14 @@
 import vscode from 'vscode';
 import { AzureEnvironment } from 'ms-rest-azure';
 import querystring from 'querystring';
-import { UserInfo, DocsSignInStatus, EXTENSION_ID, uriHandler } from '../shared';
+import { UserInfo, DocsSignInStatus, EXTENSION_ID, uriHandler, UserType } from '../shared';
 import extensionConfig from '../config';
 import { parseQuery, delay, trimEndSlash, getCorrelationId } from '../utils/utils';
-import { UserSignInSucceeded, CredentialReset, UserSignInFailed, BaseEvent, UserSignInProgress, UserSignInTriggered, UserSignOutTriggered, UserSignOutSucceeded, UserSignOutFailed, PublicUserSignIn, PublicUserSignOut, CheckIfInternal } from '../common/loggingEvents';
+import { UserSignInSucceeded, CredentialReset, UserSignInFailed, BaseEvent, UserSignInProgress, UserSignInTriggered, UserSignOutTriggered, UserSignOutSucceeded, UserSignOutFailed, PublicUserSign } from '../common/loggingEvents';
 import { EventType } from '../common/eventType';
 import { EventStream } from '../common/eventStream';
 import { KeyChain } from './keyChain';
-import { EnvironmentController, UserType } from '../common/environmentController';
+import { EnvironmentController } from '../common/environmentController';
 import { TimeOutError } from '../error/timeOutError';
 import { DocsError } from '../error/docsError';
 import { ErrorCode } from '../error/errorCode';
@@ -64,12 +64,8 @@ export class CredentialController {
     }
 
     public async signIn(correlationId: string): Promise<void> {
-        if (this._environmentController.userType === UserType.Unknow) {
-            this._eventStream.post(new CheckIfInternal());
-            return;
-        }
         if (this._environmentController.userType === UserType.PublicContributor) {
-            this._eventStream.post(new PublicUserSignIn());
+            this._eventStream.post(new PublicUserSign('SignIn'));
             return;
         }
         try {
@@ -96,12 +92,8 @@ export class CredentialController {
     }
 
     public signOut(correlationId: string) {
-        if (this._environmentController.userType === UserType.Unknow) {
-            this._eventStream.post(new CheckIfInternal());
-            return;
-        }
         if (this._environmentController.userType === UserType.PublicContributor) {
-            this._eventStream.post(new PublicUserSignOut());
+            this._eventStream.post(new PublicUserSign('SignOut'));
             return;
         }
         this._eventStream.post(new UserSignOutTriggered(correlationId));

--- a/src/credential/credentialController.ts
+++ b/src/credential/credentialController.ts
@@ -8,7 +8,7 @@ import { UserSignInSucceeded, CredentialReset, UserSignInFailed, BaseEvent, User
 import { EventType } from '../common/eventType';
 import { EventStream } from '../common/eventStream';
 import { KeyChain } from './keyChain';
-import { EnvironmentController } from '../common/environmentController';
+import { EnvironmentController, UserType } from '../common/environmentController';
 import { TimeOutError } from '../error/timeOutError';
 import { DocsError } from '../error/docsError';
 import { ErrorCode } from '../error/errorCode';
@@ -64,11 +64,11 @@ export class CredentialController {
     }
 
     public async signIn(correlationId: string): Promise<void> {
-        if (this._environmentController.userType === "undefined") {
+        if (this._environmentController.userType === UserType.Unknow) {
             this._eventStream.post(new CheckIfInternal());
             return;
         }
-        if (this._environmentController.userType === "public") {
+        if (this._environmentController.userType === UserType.PublicContributor) {
             this._eventStream.post(new PublicUserSignIn());
             return;
         }
@@ -96,11 +96,11 @@ export class CredentialController {
     }
 
     public signOut(correlationId: string) {
-        if (this._environmentController.userType === "undefined") {
+        if (this._environmentController.userType === UserType.Unknow) {
             this._eventStream.post(new CheckIfInternal());
             return;
         }
-        if (this._environmentController.userType === "public") {
+        if (this._environmentController.userType === UserType.PublicContributor) {
             this._eventStream.post(new PublicUserSignOut());
             return;
         }

--- a/src/credential/credentialController.ts
+++ b/src/credential/credentialController.ts
@@ -4,7 +4,7 @@ import querystring from 'querystring';
 import { UserInfo, DocsSignInStatus, EXTENSION_ID, uriHandler, UserType } from '../shared';
 import extensionConfig from '../config';
 import { parseQuery, delay, trimEndSlash, getCorrelationId } from '../utils/utils';
-import { UserSignInSucceeded, CredentialReset, UserSignInFailed, BaseEvent, UserSignInProgress, UserSignInTriggered, UserSignOutTriggered, UserSignOutSucceeded, UserSignOutFailed, PublicUserSign } from '../common/loggingEvents';
+import { UserSignInSucceeded, CredentialReset, UserSignInFailed, BaseEvent, UserSignInProgress, UserSignInTriggered, UserSignOutTriggered, UserSignOutSucceeded, UserSignOutFailed, PublicUserSignIn } from '../common/loggingEvents';
 import { EventType } from '../common/eventType';
 import { EventStream } from '../common/eventStream';
 import { KeyChain } from './keyChain';
@@ -65,7 +65,7 @@ export class CredentialController {
 
     public async signIn(correlationId: string): Promise<void> {
         if (this._environmentController.userType === UserType.PublicContributor) {
-            this._eventStream.post(new PublicUserSign('SignIn'));
+            this._eventStream.post(new PublicUserSignIn());
             return;
         }
         try {
@@ -73,7 +73,7 @@ export class CredentialController {
             this._signInStatus = 'SigningIn';
             this._eventStream.post(new UserSignInTriggered(correlationId));
             let userInfo;
-            if(this._environmentController.docsRepoType === 'GitHub') {
+            if (this._environmentController.docsRepoType === 'GitHub') {
                 this._eventStream.post(new UserSignInProgress(`Signing in to Docs with GitHub account...`, 'Sign-in'));
                 userInfo = await this.signInWithGitHub();
             } else {
@@ -135,7 +135,7 @@ export class CredentialController {
 
     private async signInWithGitHub(): Promise<UserInfo | null> {
         const authConfig = extensionConfig.auth[this._environmentController.env];
-        const callbackUri = await vscode.env.asExternalUri(vscode.Uri.parse(`${vscode.env.uriScheme}://${EXTENSION_ID}/github-authenticate?${querystring.stringify({response_mode : "query"})}`));
+        const callbackUri = await vscode.env.asExternalUri(vscode.Uri.parse(`${vscode.env.uriScheme}://${EXTENSION_ID}/github-authenticate?${querystring.stringify({ response_mode: "query" })}`));
         const githubQuery = querystring.stringify({
             client_id: authConfig.GitHubOauthClientId,
             redirect_uri: authConfig.GitHubOauthRedirectUrl,
@@ -180,7 +180,7 @@ export class CredentialController {
     private async signInWithAzureDevOps(): Promise<UserInfo | null> {
         const authConfig = extensionConfig.auth[this._environmentController.env];
         const callbackUri = await vscode.env.asExternalUri(
-            vscode.Uri.parse(`${vscode.env.uriScheme}://${EXTENSION_ID}/azure-devops-authenticate?${querystring.stringify({response_mode : "query"})}`));
+            vscode.Uri.parse(`${vscode.env.uriScheme}://${EXTENSION_ID}/azure-devops-authenticate?${querystring.stringify({ response_mode: "query" })}`));
         const azureDevOpsQuery = querystring.stringify({
             client_id: authConfig.AzureDevOpsOauthClientId,
             redirect_uri: authConfig.AzureDevOpsRedirectUrl,

--- a/src/credential/credentialController.ts
+++ b/src/credential/credentialController.ts
@@ -92,10 +92,6 @@ export class CredentialController {
     }
 
     public signOut(correlationId: string) {
-        if (this._environmentController.userType === UserType.PublicContributor) {
-            this._eventStream.post(new PublicUserSign('SignOut'));
-            return;
-        }
         this._eventStream.post(new UserSignOutTriggered(correlationId));
         try {
             this.resetCredential();

--- a/src/credential/credentialController.ts
+++ b/src/credential/credentialController.ts
@@ -4,7 +4,7 @@ import querystring from 'querystring';
 import { UserInfo, DocsSignInStatus, EXTENSION_ID, uriHandler } from '../shared';
 import extensionConfig from '../config';
 import { parseQuery, delay, trimEndSlash, getCorrelationId } from '../utils/utils';
-import { UserSignInSucceeded, CredentialReset, UserSignInFailed, BaseEvent, UserSignInProgress, UserSignInTriggered, UserSignOutTriggered, UserSignOutSucceeded, UserSignOutFailed } from '../common/loggingEvents';
+import { UserSignInSucceeded, CredentialReset, UserSignInFailed, BaseEvent, UserSignInProgress, UserSignInTriggered, UserSignOutTriggered, UserSignOutSucceeded, UserSignOutFailed, PublicUserSignIn, PublicUserSignOut, CheckIfInternal } from '../common/loggingEvents';
 import { EventType } from '../common/eventType';
 import { EventStream } from '../common/eventStream';
 import { KeyChain } from './keyChain';
@@ -64,6 +64,14 @@ export class CredentialController {
     }
 
     public async signIn(correlationId: string): Promise<void> {
+        if (this._environmentController.userType === "undefined") {
+            this._eventStream.post(new CheckIfInternal());
+            return;
+        }
+        if (this._environmentController.userType === "public") {
+            this._eventStream.post(new PublicUserSignIn());
+            return;
+        }
         try {
             this.resetCredential();
             this._signInStatus = 'SigningIn';
@@ -88,6 +96,14 @@ export class CredentialController {
     }
 
     public signOut(correlationId: string) {
+        if (this._environmentController.userType === "undefined") {
+            this._eventStream.post(new CheckIfInternal());
+            return;
+        }
+        if (this._environmentController.userType === "public") {
+            this._eventStream.post(new PublicUserSignOut());
+            return;
+        }
         this._eventStream.post(new UserSignOutTriggered(correlationId));
         try {
             this.resetCredential();

--- a/src/error/errorCode.ts
+++ b/src/error/errorCode.ts
@@ -19,8 +19,7 @@ export enum ErrorCode {
     TriggerBuildOnWorkspaceWithMultipleFolders = 'TriggerBuildOnWorkspaceWithMultipleFolders',
     RunDocfxFailed = 'RunDocfxFailed',
     GenerateReportFailed = 'GenerateReportFailed',
-    UndefinedUserBuild = 'UndefinedUserBuild',
-    SignedOutInternalUserBuild = 'SignOutInternalUserBuild',
+    TriggerBuildBeforeSignIn = 'TriggerBuildBeforeSignIn',
 
     // Install Dependency
     CreateInstallLockFileFailed = 'CreateInstallLockFileFailed',

--- a/src/error/errorCode.ts
+++ b/src/error/errorCode.ts
@@ -19,6 +19,8 @@ export enum ErrorCode {
     TriggerBuildOnWorkspaceWithMultipleFolders = 'TriggerBuildOnWorkspaceWithMultipleFolders',
     RunDocfxFailed = 'RunDocfxFailed',
     GenerateReportFailed = 'GenerateReportFailed',
+    UndefinedUserBuild = 'UndefinedUserBuild',
+    SignedOutInternalUserBuild = 'SignOutInternalUserBuild',
 
     // Install Dependency
     CreateInstallLockFileFailed = 'CreateInstallLockFileFailed',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,27 +157,27 @@ function createQuickPickMenu(correlationId: string, eventStream: EventStream, cr
     const currentSignInStatus = credentialController.credential.signInStatus;
     let pickItems: vscode.QuickPickItem[] = [];
 
-    if (environmentController.userType === UserType.InternalEmployee) {
+    if (environmentController.userType === UserType.MicrosoftInternalEmployee) {
         if (currentSignInStatus === 'SignedOut') {
             pickItems.push(
                 {
                     label: '$(sign-in) Sign-in',
-                    description: 'Sign in to Docs (It is required for internal users)',
+                    description: 'Sign in to Docs (It is required for Microsoft internal employees)',
                     picked: true
                 }
             );
         } else if (currentSignInStatus === 'SignedIn') {
             pickItems.push(
                 {
-                    label: '$(sign-out) Sign-out',                    
+                    label: '$(sign-out) Sign-out',
                     description: 'Sign out from Docs',
                     picked: true
                 });
-        } 
+        }
     }
     if (buildController.instanceAvailable) {
         pickItems.push(
-            {                    
+            {
                 label: '$(debug-start) Validate',
                 description: 'Trigger a validation on current repository'
             });
@@ -188,7 +188,7 @@ function createQuickPickMenu(correlationId: string, eventStream: EventStream, cr
                 description: 'Cancel the current validation'
             });
     }
-    
+
     quickPickMenu.placeholder = "Which command would you like to run?";
     quickPickMenu.items = pickItems;
     quickPickMenu.onDidChangeSelection(selection => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
 
     eventStream.post(new CheckIfInternal());
 
-
     context.subscriptions.push(
         outputChannel,
         logger,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import { BuildStatusBarObserver } from './observers/buildStatusBarObserver';
 import { CodeActionProvider } from './codeAction/codeActionProvider';
 import { ExtensionContext } from './extensionContext';
 import config from './config';
-import { EnvironmentController } from './common/environmentController';
+import { EnvironmentController, UserType } from './common/environmentController';
 import { TelemetryObserver } from './observers/telemetryObserver';
 import { getCorrelationId } from './utils/utils';
 import { QuickPickTriggered, QuickPickCommandSelected, CheckIfInternal } from './common/loggingEvents';
@@ -135,7 +135,7 @@ function createQuickPickMenu(correlationId: string, eventStream: EventStream, cr
     const currentSignInStatus = credentialController.credential.signInStatus;
     let pickItems: vscode.QuickPickItem[] = [];
 
-    if (environmentController.userType === "internal") {
+    if (environmentController.userType === UserType.InternalEmployee) {
         if (currentSignInStatus === 'SignedOut') {
             pickItems.push(
                 {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,12 +157,12 @@ function createQuickPickMenu(correlationId: string, eventStream: EventStream, cr
     const currentSignInStatus = credentialController.credential.signInStatus;
     let pickItems: vscode.QuickPickItem[] = [];
 
-    if (environmentController.userType === UserType.MicrosoftInternalEmployee) {
+    if (environmentController.userType === UserType.MicrosoftEmployee) {
         if (currentSignInStatus === 'SignedOut') {
             pickItems.push(
                 {
                     label: '$(sign-in) Sign-in',
-                    description: 'Sign in to Docs (It is required for Microsoft internal employees)',
+                    description: 'Sign in to Docs (It is required for Microsoft employees)',
                     picked: true
                 }
             );

--- a/src/observers/docsLoggerObserver.ts
+++ b/src/observers/docsLoggerObserver.ts
@@ -149,7 +149,7 @@ export class DocsLoggerObserver {
     }
 
     private handlePublicUserSignIn() {
-        this.appendLine(`Sign in failed: Sign in is only available for Microsoft internal employees.`);
+        this.appendLine(`Sign in failed: Sign in is only available for Microsoft employees.`);
     }
 
     // Build

--- a/src/observers/docsLoggerObserver.ts
+++ b/src/observers/docsLoggerObserver.ts
@@ -97,6 +97,9 @@ export class DocsLoggerObserver {
             case EventType.PlatformInfoRetrieved:
                 this.handlePlatformInfoRetrieved(<PlatformInfoRetrieved>event);
                 break;
+            case EventType.ExtensionActivated:
+                this.handleExtensionActivated();
+                break;
             case EventType.TriggerCommandWithUnkownUserType:
                 this.handleUserTypeUnknown();
                 break;
@@ -298,7 +301,11 @@ export class DocsLoggerObserver {
         this.appendLine();
     }
 
+    private handleExtensionActivated() {
+        this.appendLine(`Extension activated.`);
+    }
+
     private handleUserTypeUnknown() {
-        this.appendLine(`You can reset in Settings -> Extensions -> Doc Validation -> User Type`);
+        this.appendLine(`Command triggered when user type is unknown.`);
     }
 }

--- a/src/observers/docsLoggerObserver.ts
+++ b/src/observers/docsLoggerObserver.ts
@@ -97,6 +97,9 @@ export class DocsLoggerObserver {
             case EventType.PlatformInfoRetrieved:
                 this.handlePlatformInfoRetrieved(<PlatformInfoRetrieved>event);
                 break;
+            case EventType.TriggerCommandWithUnkownUserType:
+                this.handleUserTypeUnknown();
+                break;
         }
     }
 
@@ -293,5 +296,9 @@ export class DocsLoggerObserver {
     private handlePlatformInfoRetrieved(event: PlatformInfoRetrieved) {
         this.appendLine(`Platform: ${event.platformInfo.toString()}`);
         this.appendLine();
+    }
+
+    private handleUserTypeUnknown() {
+        this.appendLine(`You can reset in Settings -> Extensions -> Doc Validation -> User Type`);
     }
 }

--- a/src/observers/docsLoggerObserver.ts
+++ b/src/observers/docsLoggerObserver.ts
@@ -31,6 +31,9 @@ export class DocsLoggerObserver {
             case EventType.UserSignInProgress:
                 this.handleUserSignInProgress(<UserSignInProgress>event);
                 break;
+            case EventType.PublicUserSignIn:
+                this.handlePublicUserSignIn();
+                break;
             // Build
             case EventType.RepositoryInfoRetrieved:
                 this.handleRepositoryInfoRetrieved(<RepositoryInfoRetrieved>event);
@@ -101,7 +104,7 @@ export class DocsLoggerObserver {
                 this.handleExtensionActivated();
                 break;
             case EventType.TriggerCommandWithUnkownUserType:
-                this.handleUserTypeUnknown();
+                this.handleTriggerCommandWithUnkownUserType();
                 break;
         }
     }
@@ -143,6 +146,10 @@ export class DocsLoggerObserver {
     private handleUserSignInProgress(event: UserSignInProgress) {
         let tag = event.tag ? `[${event.tag}] ` : '';
         this.appendLine(`${tag}${event.message}`);
+    }
+
+    private handlePublicUserSignIn() {
+        this.appendLine(`Sign in failed: Sign in is only available for Microsoft internal employees.`);
     }
 
     // Build
@@ -305,7 +312,7 @@ export class DocsLoggerObserver {
         this.appendLine(`Extension activated.`);
     }
 
-    private handleUserTypeUnknown() {
+    private handleTriggerCommandWithUnkownUserType() {
         this.appendLine(`Command triggered when user type is unknown.`);
     }
 }

--- a/src/observers/docsOutputChannelObserver.ts
+++ b/src/observers/docsOutputChannelObserver.ts
@@ -18,6 +18,10 @@ export class DocsOutputChannelObserver {
                     this._channel.show();
                 }
                 break;
-            }
+            case EventType.TriggerCommandWithUnkownUserType:
+                this._channel.show();
+                break;
+        }
+
     }
 }

--- a/src/observers/docsOutputChannelObserver.ts
+++ b/src/observers/docsOutputChannelObserver.ts
@@ -18,9 +18,6 @@ export class DocsOutputChannelObserver {
                     this._channel.show();
                 }
                 break;
-            case EventType.TriggerCommandWithUnkownUserType:
-                this._channel.show();
-                break;
         }
 
     }

--- a/src/observers/docsOutputChannelObserver.ts
+++ b/src/observers/docsOutputChannelObserver.ts
@@ -19,6 +19,5 @@ export class DocsOutputChannelObserver {
                 }
                 break;
         }
-
     }
 }

--- a/src/observers/errorMessageObserver.ts
+++ b/src/observers/errorMessageObserver.ts
@@ -55,10 +55,10 @@ export class ErrorMessageObserver {
                 action = new MessageAction('Sign in', 'docs.signIn');
                 break;
         }
-        this.showErrorMessage(`Validation of current workspace failed. ${event.err.message} Please check the channel output for details`, action);
+        this.showErrorMessage(`Repository validation failed. ${event.err.message} Check the channel output for details`, action);
     }
 
     private handlePublicUserSignIn() {
-        this.showErrorMessage(`Sign in is only available for Microsoft internal employees.`);
+        this.showErrorMessage(`Sign in is only available for Microsoft employees.`);
     }
 }

--- a/src/observers/errorMessageObserver.ts
+++ b/src/observers/errorMessageObserver.ts
@@ -1,7 +1,7 @@
 import vscode from 'vscode';
 import { EventType } from '../common/eventType';
 import { BaseEvent, UserSignInFailed, UserSignInCompleted, UserSignOutCompleted, UserSignOutFailed, BuildCompleted, BuildFailed } from '../common/loggingEvents';
-import { MessageAction } from '../shared';
+import { MessageAction, EXTENSION_NAME, USER_TYPE, UserType } from '../shared';
 import { ErrorCode } from '../error/errorCode';
 import { DocsError } from '../error/docsError';
 import { DocfxExecutionResult } from '../build/buildResult';
@@ -29,15 +29,20 @@ export class ErrorMessageObserver {
             case EventType.PublicUserSignIn:
                 this.handlePublicUserSignIn();
                 break;
+            case EventType.TriggerCommandWithUnkownUserType:
+                this.handleCommandWithUnkownUserTypeTriggered();
+                break;
         }
     }
 
-    private async showErrorMessage(message: string, action?: MessageAction) {
-        let infoMsg = `[Docs Validation] ${message}`;
-        if (action && action.description) {
-            infoMsg += `\n${action.description}`;
-        }
-        let input = <MessageAction>(await vscode.window.showErrorMessage(infoMsg, action));
+    private async showErrorMessage(message: string, ...actions: MessageAction[]) {
+        let errorMsg = `[Docs Validation] ${message}`;
+        actions.forEach((action) => {
+            if (action && action.description) {
+                errorMsg += ` ${action.description}`;
+            }
+        });
+        let input = <MessageAction>(await vscode.window.showErrorMessage(errorMsg, ...actions));
         if (input) {
             if (input.command) {
                 vscode.commands.executeCommand(input.command, undefined);
@@ -60,5 +65,29 @@ export class ErrorMessageObserver {
 
     private handlePublicUserSignIn() {
         this.showErrorMessage(`Sign in is only available for Microsoft employees.`);
+    }
+
+    private handleCommandWithUnkownUserTypeTriggered() {
+        this.showErrorMessage(
+            `The command you triggered needs user type information. Please choose either Microsoft employee or Public contributor. ` +
+            `You can change your selection later if needed in the extension settings (Docs validation -> User type).`,
+            new MessageAction(
+                "Microsoft employee",
+                undefined,
+                undefined,
+                () => {
+                    const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
+                    extensionConfig.update(USER_TYPE, UserType.MicrosoftEmployee, true);
+                }
+            ),
+            new MessageAction(
+                "Public contributor",
+                undefined,
+                undefined,
+                () => {
+                    const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
+                    extensionConfig.update(USER_TYPE, UserType.PublicContributor, true);
+                }
+            ));
     }
 }

--- a/src/observers/errorMessageObserver.ts
+++ b/src/observers/errorMessageObserver.ts
@@ -26,6 +26,9 @@ export class ErrorMessageObserver {
                     this.handleBuildFailed(<BuildFailed>event);
                 }
                 break;
+            case EventType.PublicUserSignIn:
+                this.handlePublicUserSignIn();
+                break;
         }
     }
 
@@ -52,6 +55,10 @@ export class ErrorMessageObserver {
                 action = new MessageAction('Sign in', 'docs.signIn');
                 break;
         }
-        this.showErrorMessage(`Validation of current workspace failed (${event.err.message}). Please check the channel output for details`, action);
+        this.showErrorMessage(`Validation of current workspace failed. ${event.err.message} Please check the channel output for details`, action);
+    }
+
+    private handlePublicUserSignIn() {
+        this.showErrorMessage(`Sign in is only available for Microsoft internal employees.`);
     }
 }

--- a/src/observers/infoMessageObserver.ts
+++ b/src/observers/infoMessageObserver.ts
@@ -67,7 +67,7 @@ export class InfoMessageObserver {
     private handleBuildTriggered(event: BuildTriggered) {
         if (!event.signedIn && this._environmentController.enableSignRecommendHint) {
             this.showInfoMessage(
-                `If you are a Microsoft internal employee, you are recommended to login to the Docs system by clicking 'Docs Validation' in the status bar and 'Sign-in' in command palette,` +
+                `If you are a Microsoft employee, you are recommended to login to the Docs system by clicking 'Docs Validation' in the status bar and 'Sign-in' in command palette,` +
                 ` or you may get some validation errors if some non-live data (e.g. UID, moniker) has been used.`,
                 new MessageAction(
                     "Don't show this message again",
@@ -84,15 +84,15 @@ export class InfoMessageObserver {
     private handleExtensionActivated() {
         if (this._environmentController.userType === UserType.Unknown) {
             this.showInfoMessage(
-                `Are you a Microsoft internal employee or public contributor? We need the information to provide better validation experience. ` +
-                `You are still able to change it by the extension settings (Docs validation -> User type) after this selection`,
+                `Are you a Microsoft employee or a public contributor? We need this information to provide a better validation experience. ` +
+                `You can change your selection later if needed in the extension settings (Docs validation -> User type).`,
                 new MessageAction(
-                    "Microsoft internal employee",
+                    "Microsoft employee",
                     undefined,
                     undefined,
                     () => {
                         const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-                        extensionConfig.update(USER_TYPE, UserType.MicrosoftInternalEmployee, true);
+                        extensionConfig.update(USER_TYPE, UserType.MicrosoftEmployee, true);
                     }
                 ),
                 new MessageAction(
@@ -109,15 +109,15 @@ export class InfoMessageObserver {
 
     private handleCommandWithUnkownUserTypeTriggered() {
         this.showInfoMessage(
-            `The command you just triggered needs user type information. Please choose either Microsoft internal employee or Public contributor. ` +
-            `You are still able to change it by the extension settings (Docs validation -> User type) after this selection`,
+            `The command you triggered needs user type information. Please choose either Microsoft employee or Public contributor. ` +
+            `You can change your selection later if needed in the extension settings (Docs validation -> User type).`,
             new MessageAction(
-                "Microsoft internal employee",
+                "Microsoft employee",
                 undefined,
                 undefined,
                 () => {
                     const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-                    extensionConfig.update(USER_TYPE, UserType.MicrosoftInternalEmployee, true);
+                    extensionConfig.update(USER_TYPE, UserType.MicrosoftEmployee, true);
                 }
             ),
             new MessageAction(

--- a/src/observers/infoMessageObserver.ts
+++ b/src/observers/infoMessageObserver.ts
@@ -2,7 +2,7 @@ import vscode from 'vscode';
 import { BaseEvent, UserSignInCompleted, UserSignOutCompleted, BuildCompleted, BuildTriggered } from '../common/loggingEvents';
 import { EventType } from '../common/eventType';
 import { MessageAction, EXTENSION_NAME, SIGN_RECOMMEND_HINT_CONFIG_NAME, USER_TYPE } from '../shared';
-import { EnvironmentController } from '../common/environmentController';
+import { EnvironmentController, UserType } from '../common/environmentController';
 
 export class InfoMessageObserver {
     constructor(private _environmentController: EnvironmentController) { }
@@ -100,7 +100,7 @@ export class InfoMessageObserver {
     }
 
     private checkIfInternal() {
-        if (this._environmentController.userType === "undefined") {
+        if (this._environmentController.userType === UserType.Unknow) {
             this.showInfoMessageWithMultipleChoices(
                 `Are you an internal user?`,
                 new MessageAction(
@@ -109,7 +109,7 @@ export class InfoMessageObserver {
                     undefined,
                     () => {
                         const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-                        extensionConfig.update(USER_TYPE, "internal", true);
+                        extensionConfig.update(USER_TYPE, UserType.InternalEmployee, true);
                     }
                 ),
                 new MessageAction(
@@ -118,7 +118,7 @@ export class InfoMessageObserver {
                     undefined,
                     () => {
                         const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-                        extensionConfig.update(USER_TYPE, "public", true);
+                        extensionConfig.update(USER_TYPE, UserType.PublicContributor, true);
                     }
                 ));
         }

--- a/src/observers/infoMessageObserver.ts
+++ b/src/observers/infoMessageObserver.ts
@@ -1,8 +1,8 @@
 import vscode from 'vscode';
-import { BaseEvent, UserSignInCompleted, UserSignOutCompleted, BuildCompleted, BuildTriggered } from '../common/loggingEvents';
+import { BaseEvent, UserSignInCompleted, UserSignOutCompleted, BuildCompleted, BuildTriggered, PublicUserSign } from '../common/loggingEvents';
 import { EventType } from '../common/eventType';
-import { MessageAction, EXTENSION_NAME, SIGN_RECOMMEND_HINT_CONFIG_NAME, USER_TYPE } from '../shared';
-import { EnvironmentController, UserType } from '../common/environmentController';
+import { MessageAction, EXTENSION_NAME, SIGN_RECOMMEND_HINT_CONFIG_NAME, USER_TYPE, UserType } from '../shared';
+import { EnvironmentController } from '../common/environmentController';
 
 export class InfoMessageObserver {
     constructor(private _environmentController: EnvironmentController) { }
@@ -29,14 +29,18 @@ export class InfoMessageObserver {
                     this.handleBuildJobSucceeded();
                 }
                 break;
-            case EventType.CheckIfInternal:
+            case EventType.ExtensionActivated:
                 this.checkIfInternal();
                 break;
-            case EventType.PublicUserSignIn:
-                this.handlePublicSignIn();
+            case EventType.TriggerCommandWithUnkownUserType:
+                this.checkIfInternal();
                 break;
-            case EventType.PublicUserSignOut:
-                this.handlePublicSignOut();
+            case EventType.PublicUserSign:
+                if ((<PublicUserSign>event).action === 'SignIn') {
+                    this.handlePublicSignIn();
+                } else {
+                    this.handlePublicSignOut();
+                }
                 break;
         }
     }

--- a/src/observers/infoMessageObserver.ts
+++ b/src/observers/infoMessageObserver.ts
@@ -35,9 +35,6 @@ export class InfoMessageObserver {
             case EventType.TriggerCommandWithUnkownUserType:
                 this.handleCommandWithUnkownUserTypeTriggered();
                 break;
-            case EventType.PublicUserSignIn:
-                this.handlePublicSignIn();
-                break;
         }
     }
 
@@ -70,7 +67,7 @@ export class InfoMessageObserver {
     private handleBuildTriggered(event: BuildTriggered) {
         if (!event.signedIn && this._environmentController.enableSignRecommendHint) {
             this.showInfoMessage(
-                `If you are a Microsoft internal user, you are recommended to login to the Docs system by clicking 'Docs Validation' in the status bar and 'Sign-in' in command palette,` +
+                `If you are a Microsoft internal employee, you are recommended to login to the Docs system by clicking 'Docs Validation' in the status bar and 'Sign-in' in command palette,` +
                 ` or you may get some validation errors if some non-live data (e.g. UID, moniker) has been used.`,
                 new MessageAction(
                     "Don't show this message again",
@@ -85,16 +82,17 @@ export class InfoMessageObserver {
     }
 
     private handleExtensionActivated() {
-        if (this._environmentController.userType === UserType.Unknow) {
+        if (this._environmentController.userType === UserType.Unknown) {
             this.showInfoMessage(
-                `Are you a Microsoft employee or public contributor? We need the information to provide better validation experience. You can change it in Settings -> Extensions -> Doc Validation -> User type.`,
+                `Are you a Microsoft internal employee or public contributor? We need the information to provide better validation experience. ` +
+                `You are still able to change it by the extension settings (Docs validation -> User type) after this selection`,
                 new MessageAction(
                     "Microsoft internal employee",
                     undefined,
                     undefined,
                     () => {
                         const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-                        extensionConfig.update(USER_TYPE, UserType.InternalEmployee, true);
+                        extensionConfig.update(USER_TYPE, UserType.MicrosoftInternalEmployee, true);
                     }
                 ),
                 new MessageAction(
@@ -110,35 +108,26 @@ export class InfoMessageObserver {
     }
 
     private handleCommandWithUnkownUserTypeTriggered() {
-        if (this._environmentController.userType === UserType.Unknow) {
-            this.showInfoMessage(
-                `The command you just tried to operate needs your user type provided, please choose first. You can change it in Settings -> Extensions -> Doc Validation -> User type.`,
-                new MessageAction(
-                    "Microsoft internal employee",
-                    undefined,
-                    undefined,
-                    () => {
-                        const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-                        extensionConfig.update(USER_TYPE, UserType.InternalEmployee, true);
-                    }
-                ),
-                new MessageAction(
-                    "Public contributor",
-                    undefined,
-                    undefined,
-                    () => {
-                        const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-                        extensionConfig.update(USER_TYPE, UserType.PublicContributor, true);
-                    }
-                ));
-        }
-    }
-
-    private handlePublicSignIn() {
         this.showInfoMessage(
-            `Sign in is only available for Microsoft employees`,
+            `The command you just triggered needs user type information. Please choose either Microsoft internal employee or Public contributor. ` +
+            `You are still able to change it by the extension settings (Docs validation -> User type) after this selection`,
             new MessageAction(
-                "Ok"
+                "Microsoft internal employee",
+                undefined,
+                undefined,
+                () => {
+                    const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
+                    extensionConfig.update(USER_TYPE, UserType.MicrosoftInternalEmployee, true);
+                }
+            ),
+            new MessageAction(
+                "Public contributor",
+                undefined,
+                undefined,
+                () => {
+                    const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
+                    extensionConfig.update(USER_TYPE, UserType.PublicContributor, true);
+                }
             ));
     }
 }

--- a/src/observers/infoMessageObserver.ts
+++ b/src/observers/infoMessageObserver.ts
@@ -87,7 +87,7 @@ export class InfoMessageObserver {
     private handleExtensionActivated() {
         if (this._environmentController.userType === UserType.Unknow) {
             this.showInfoMessage(
-                `Are you a Microsoft employee or public contributor? We need the information to provide better validation experience.`,
+                `Are you a Microsoft employee or public contributor? We need the information to provide better validation experience. You can change it in Settings -> Extensions -> Doc Validation -> User type.`,
                 new MessageAction(
                     "Microsoft internal employee",
                     undefined,
@@ -112,7 +112,7 @@ export class InfoMessageObserver {
     private handleCommandWithUnkownUserTypeTriggered() {
         if (this._environmentController.userType === UserType.Unknow) {
             this.showInfoMessage(
-                `The command you just tried to operate needs your user type provided, please choose first.`,
+                `The command you just tried to operate needs your user type provided, please choose first. You can change it in Settings -> Extensions -> Doc Validation -> User type.`,
                 new MessageAction(
                     "Microsoft internal employee",
                     undefined,

--- a/src/observers/infoMessageObserver.ts
+++ b/src/observers/infoMessageObserver.ts
@@ -32,9 +32,6 @@ export class InfoMessageObserver {
             case EventType.ExtensionActivated:
                 this.handleExtensionActivated();
                 break;
-            case EventType.TriggerCommandWithUnkownUserType:
-                this.handleCommandWithUnkownUserTypeTriggered();
-                break;
         }
     }
 
@@ -105,29 +102,5 @@ export class InfoMessageObserver {
                     }
                 ));
         }
-    }
-
-    private handleCommandWithUnkownUserTypeTriggered() {
-        this.showInfoMessage(
-            `The command you triggered needs user type information. Please choose either Microsoft employee or Public contributor. ` +
-            `You can change your selection later if needed in the extension settings (Docs validation -> User type).`,
-            new MessageAction(
-                "Microsoft employee",
-                undefined,
-                undefined,
-                () => {
-                    const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-                    extensionConfig.update(USER_TYPE, UserType.MicrosoftEmployee, true);
-                }
-            ),
-            new MessageAction(
-                "Public contributor",
-                undefined,
-                undefined,
-                () => {
-                    const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
-                    extensionConfig.update(USER_TYPE, UserType.PublicContributor, true);
-                }
-            ));
     }
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -34,6 +34,8 @@ export type DocsSignInStatus = 'Initializing' | 'SigningIn' | 'SignedIn' | 'Sign
 
 export type DocsRepoType = 'GitHub' | 'Azure DevOps';
 
+export type SignAction = 'SignIn' | 'SignOut';
+
 export interface UserInfo {
     readonly signType: DocsRepoType;
     readonly userId: string;
@@ -59,4 +61,10 @@ export interface ReportItem {
     restoreDuration: number;
     buildDuration: number;
     isInitialRun: boolean;
+}
+
+export enum UserType {
+    InternalEmployee = "Microsoft Internal Employee",
+    PublicContributor = "Public Contributor",
+    Unknow = ""
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -34,8 +34,6 @@ export type DocsSignInStatus = 'Initializing' | 'SigningIn' | 'SignedIn' | 'Sign
 
 export type DocsRepoType = 'GitHub' | 'Azure DevOps';
 
-export type SignAction = 'SignIn' | 'SignOut';
-
 export interface UserInfo {
     readonly signType: DocsRepoType;
     readonly userId: string;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -62,7 +62,7 @@ export interface ReportItem {
 }
 
 export enum UserType {
-    MicrosoftInternalEmployee = "Microsoft Internal Employee",
+    MicrosoftEmployee = "Microsoft Employee",
     PublicContributor = "Public Contributor",
     Unknown = ""
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -62,7 +62,7 @@ export interface ReportItem {
 }
 
 export enum UserType {
-    InternalEmployee = "Microsoft Internal Employee",
+    MicrosoftInternalEmployee = "Microsoft Internal Employee",
     PublicContributor = "Public Contributor",
-    Unknow = ""
+    Unknown = ""
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -17,6 +17,8 @@ export const DEBUG_MODE_CONFIG_NAME = 'debugMode.enable';
 
 export const SIGN_RECOMMEND_HINT_CONFIG_NAME = 'hint.signRecommend';
 
+export const USER_TYPE = 'userType';
+
 // Environment
 export type Environment = 'PROD' | 'PPE';
 

--- a/test/e2eTests/extension.e2e.test.ts
+++ b/test/e2eTests/extension.e2e.test.ts
@@ -81,8 +81,8 @@ describe('E2E Test', () => {
         (async function () {
             let dispose = eventStream.subscribe((event: BaseEvent) => {
                 switch (event.type) {
-                    case EventType.CredentialReset:	
-                        triggerCommand('docs.build');	
+                    case EventType.CredentialReset:
+                        triggerCommand('docs.build');
                         break;
                     case EventType.BuildCompleted:
                         finalCheck(<BuildCompleted>event);

--- a/test/e2eTests/extension.e2e.test.ts
+++ b/test/e2eTests/extension.e2e.test.ts
@@ -125,7 +125,7 @@ describe('E2E Test', () => {
 
     it('Sign in to Docs and trigger build', (done) => {
         sinon.stub(environmentController, "userType").get(function getUserType() {
-            return UserType.MicrosoftInternalEmployee;
+            return UserType.MicrosoftEmployee;
         });
         (async function () {
             let dispose = eventStream.subscribe((event: BaseEvent) => {

--- a/test/e2eTests/extension.e2e.test.ts
+++ b/test/e2eTests/extension.e2e.test.ts
@@ -125,7 +125,7 @@ describe('E2E Test', () => {
 
     it('Sign in to Docs and trigger build', (done) => {
         sinon.stub(environmentController, "userType").get(function getUserType() {
-            return UserType.InternalEmployee;
+            return UserType.MicrosoftInternalEmployee;
         });
         (async function () {
             let dispose = eventStream.subscribe((event: BaseEvent) => {

--- a/test/e2eTests/extension.e2e.test.ts
+++ b/test/e2eTests/extension.e2e.test.ts
@@ -54,7 +54,7 @@ describe('E2E Test', () => {
         assert.notEqual(extension, undefined);
 
         eventStream = extension.exports.eventStream;
-        environmentController = extension.exports.environmentController;;
+        environmentController = extension.exports.environmentController;
         testEventBus = new TestEventBus(eventStream);
     });
 
@@ -81,6 +81,9 @@ describe('E2E Test', () => {
         (async function () {
             let dispose = eventStream.subscribe((event: BaseEvent) => {
                 switch (event.type) {
+                    case EventType.CredentialReset:	
+                        triggerCommand('docs.build');	
+                        break;
                     case EventType.BuildCompleted:
                         finalCheck(<BuildCompleted>event);
                         break;
@@ -92,7 +95,7 @@ describe('E2E Test', () => {
                 }
             });
 
-            triggerCommand('docs.build');
+            triggerCommand('docs.signOut');
 
             function finalCheck(event: BuildCompleted) {
                 detailE2EOutput['build without sign-in'] = testEventBus.getEvents();

--- a/test/e2eTests/extension.e2e.test.ts
+++ b/test/e2eTests/extension.e2e.test.ts
@@ -74,7 +74,7 @@ describe('E2E Test', () => {
         fs.writeJSONSync(detailE2EOutputFile, detailE2EOutput);
     });
 
-    it.only('build without sign-in', async (done) => {
+    it.only('build without sign-in', (done) => {
         sinon.stub(environmentController, "userType").get(function getUserType() {
             return UserType.PublicContributor;
         });

--- a/test/e2eTests/extension.e2e.test.ts
+++ b/test/e2eTests/extension.e2e.test.ts
@@ -74,7 +74,7 @@ describe('E2E Test', () => {
         fs.writeJSONSync(detailE2EOutputFile, detailE2EOutput);
     });
 
-    it.only('build without sign-in', (done) => {
+    it('build without sign-in', (done) => {
         sinon.stub(environmentController, "userType").get(function getUserType() {
             return UserType.PublicContributor;
         });

--- a/test/e2eTests/extension.e2e.test.ts
+++ b/test/e2eTests/extension.e2e.test.ts
@@ -10,6 +10,8 @@ import { uriHandler } from '../../src/shared';
 import { DocfxExecutionResult } from '../../src/build/buildResult';
 import TestEventBus from '../utils/testEventBus';
 import { EventStream } from '../../src/common/eventStream';
+import { EXTENSION_NAME, USER_TYPE } from '../../src/shared';
+import { UserType } from '../../src/common/environmentController';
 
 const detailE2EOutput: any = {};
 
@@ -72,15 +74,14 @@ describe('E2E Test', () => {
     });
 
     it.only('build without sign-in', (done) => {
+        const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
+        extensionConfig.update(USER_TYPE, UserType.PublicContributor, true);
         (async function () {
             let dispose = eventStream.subscribe((event: BaseEvent) => {
                 switch (event.type) {
-                    case EventType.CredentialReset:
-                        triggerCommand('docs.build');
-                        break;
                     case EventType.BuildCompleted:
                         finalCheck(<BuildCompleted>event);
-                    break;
+                        break;
                     case EventType.BuildInstantReleased:
                         dispose.unsubscribe();
                         testEventBus.dispose();
@@ -89,7 +90,7 @@ describe('E2E Test', () => {
                 }
             });
 
-            triggerCommand('docs.signOut');
+            triggerCommand('docs.build');
 
             function finalCheck(event: BuildCompleted) {
                 detailE2EOutput['build without sign-in'] = testEventBus.getEvents();
@@ -118,6 +119,8 @@ describe('E2E Test', () => {
     });
 
     it('Sign in to Docs and trigger build', (done) => {
+        const extensionConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(EXTENSION_NAME, undefined);
+        extensionConfig.update(USER_TYPE, UserType.InternalEmployee, true);
         (async function () {
             let dispose = eventStream.subscribe((event: BaseEvent) => {
                 switch (event.type) {

--- a/test/e2eTests/extension.e2e.test.ts
+++ b/test/e2eTests/extension.e2e.test.ts
@@ -10,7 +10,7 @@ import { uriHandler, UserType } from '../../src/shared';
 import { DocfxExecutionResult } from '../../src/build/buildResult';
 import TestEventBus from '../utils/testEventBus';
 import { EventStream } from '../../src/common/eventStream';
-import ExtensionExports from '../../src/common/extensionExport';
+import { EnvironmentController } from '../../src/common/environmentController';
 
 const detailE2EOutput: any = {};
 
@@ -25,7 +25,7 @@ describe('E2E Test', () => {
     let sinon: SinonSandbox;
     let eventStream: EventStream;
     let testEventBus: TestEventBus;
-    let extension: vscode.Extension<ExtensionExports>;
+    let environmentController: EnvironmentController;
 
     before(async () => {
         if (!process.env.VSCODE_DOCS_BUILD_EXTENSION_BUILD_USER_TOKEN) {
@@ -50,10 +50,11 @@ describe('E2E Test', () => {
             }
         );
 
-        extension = await ensureExtensionActivatedAndInitializationFinished();
+        const extension = await ensureExtensionActivatedAndInitializationFinished();
         assert.notEqual(extension, undefined);
 
         eventStream = extension.exports.eventStream;
+        environmentController = extension.exports.environmentController;;
         testEventBus = new TestEventBus(eventStream);
     });
 
@@ -74,7 +75,6 @@ describe('E2E Test', () => {
     });
 
     it.only('build without sign-in', async (done) => {
-        const environmentController = extension.exports.environmentController;
         sinon.stub(environmentController, "userType").get(function getUserType() {
             return UserType.PublicContributor;
         });
@@ -121,7 +121,6 @@ describe('E2E Test', () => {
     });
 
     it('Sign in to Docs and trigger build', (done) => {
-        const environmentController = extension.exports.environmentController;
         sinon.stub(environmentController, "userType").get(function getUserType() {
             return UserType.InternalEmployee;
         });

--- a/test/unitTests/build/buildController.test.ts
+++ b/test/unitTests/build/buildController.test.ts
@@ -225,7 +225,7 @@ describe('BuildController', () => {
             new BuildTriggered('fakedCorrelationId', false),
             new BuildFailed('fakedCorrelationId', undefined, 1,
                 new DocsError(
-                    `Please sign in first`,
+                    `It is required for internal employees to sign in before validation, please sign in first.`,
                     ErrorCode.TriggerBuildBeforeSignIn
                 ))
         ]);

--- a/test/unitTests/build/buildController.test.ts
+++ b/test/unitTests/build/buildController.test.ts
@@ -13,11 +13,10 @@ import { BuildInput } from '../../../src/build/buildInput';
 import { BuildController } from '../../../src/build/buildController';
 import { DiagnosticController } from '../../../src/build/diagnosticController';
 import { fakedCredential, getFakedBuildExecutor, defaultLogPath, defaultOutputPath, getFakeEnvironmentController } from '../../utils/faker';
-import { BuildTriggered, BuildFailed, BuildProgress, RepositoryInfoRetrieved, BuildInstantAllocated, BuildStarted, BuildSucceeded, BuildInstantReleased, BuildCanceled, CancelBuildTriggered, CancelBuildSucceeded, CredentialExpired, CheckIfInternal } from '../../../src/common/loggingEvents';
+import { BuildTriggered, BuildFailed, BuildProgress, RepositoryInfoRetrieved, BuildInstantAllocated, BuildStarted, BuildSucceeded, BuildInstantReleased, BuildCanceled, CancelBuildTriggered, CancelBuildSucceeded, CredentialExpired } from '../../../src/common/loggingEvents';
 import { DocsError } from '../../../src/error/docsError';
 import { ErrorCode } from '../../../src/error/errorCode';
 import { Credential } from '../../../src/credential/credentialController';
-import { EnvironmentController, UserType } from '../../../src/common/environmentController';
 
 const expectedBuildInput = <BuildInput>{
     buildType: 'FullBuild',
@@ -230,38 +229,7 @@ describe('BuildController', () => {
                     ErrorCode.SignedOutInternalUserBuild
                 ))
         ]);
-    });
-
-    it('Trigger build before choosing over internal and public', async () => {
-        buildController = new BuildController(
-            getFakedBuildExecutor(
-                DocfxExecutionResult.Succeeded,
-                (correlationId: string, input: BuildInput, buildUserToken: string) => {
-                    tokenUsedForBuild = buildUserToken;
-                }),
-            fakedOPBuildAPIClient, undefined,
-            <EnvironmentController>{
-                env: 'PROD',
-                docsRepoType: 'GitHub',
-                debugMode: false,
-                enableSignRecommendHint: true,
-                userType: UserType.Unknow
-            }, 
-            eventStream
-        );
-        await buildController.build('fakedCorrelationId', <Credential>{
-            signInStatus: 'Initializing'
-        });
-        assert.deepStrictEqual(testEventBus.getEvents(), [
-            new BuildTriggered('fakedCorrelationId', false),
-            new CheckIfInternal(),
-            new BuildFailed('fakedCorrelationId', undefined, 1,
-                new DocsError(
-                    `Validation needs user type provided, make a choice first`,
-                    ErrorCode.UndefinedUserBuild
-                ))
-        ]);
-    });                                                
+    });                                               
 
     it('Successfully build', async () => {
         // First time

--- a/test/unitTests/build/buildController.test.ts
+++ b/test/unitTests/build/buildController.test.ts
@@ -226,10 +226,10 @@ describe('BuildController', () => {
             new BuildFailed('fakedCorrelationId', undefined, 1,
                 new DocsError(
                     `Please sign in first`,
-                    ErrorCode.SignedOutInternalUserBuild
+                    ErrorCode.TriggerBuildBeforeSignIn
                 ))
         ]);
-    });                                               
+    });
 
     it('Successfully build', async () => {
         // First time

--- a/test/unitTests/build/buildController.test.ts
+++ b/test/unitTests/build/buildController.test.ts
@@ -17,7 +17,7 @@ import { BuildTriggered, BuildFailed, BuildProgress, RepositoryInfoRetrieved, Bu
 import { DocsError } from '../../../src/error/docsError';
 import { ErrorCode } from '../../../src/error/errorCode';
 import { Credential } from '../../../src/credential/credentialController';
-import { EnvironmentController } from '../../../src/common/environmentController';
+import { EnvironmentController, UserType } from '../../../src/common/environmentController';
 
 const expectedBuildInput = <BuildInput>{
     buildType: 'FullBuild',
@@ -245,7 +245,7 @@ describe('BuildController', () => {
                 docsRepoType: 'GitHub',
                 debugMode: false,
                 enableSignRecommendHint: true,
-                userType: "undefined"
+                userType: UserType.Unknow
             }, 
             eventStream
         );

--- a/test/unitTests/build/buildController.test.ts
+++ b/test/unitTests/build/buildController.test.ts
@@ -225,7 +225,7 @@ describe('BuildController', () => {
             new BuildTriggered('fakedCorrelationId', false),
             new BuildFailed('fakedCorrelationId', undefined, 1,
                 new DocsError(
-                    `It is required for internal employees to sign in before validation, please sign in first.`,
+                    `It is required for Microsoft internal employees to sign in before validation, please sign in first.`,
                     ErrorCode.TriggerBuildBeforeSignIn
                 ))
         ]);

--- a/test/unitTests/build/buildController.test.ts
+++ b/test/unitTests/build/buildController.test.ts
@@ -225,7 +225,7 @@ describe('BuildController', () => {
             new BuildTriggered('fakedCorrelationId', false),
             new BuildFailed('fakedCorrelationId', undefined, 1,
                 new DocsError(
-                    `It is required for Microsoft internal employees to sign in before validation, please sign in first.`,
+                    `Microsoft employees must sign in before validating.`,
                     ErrorCode.TriggerBuildBeforeSignIn
                 ))
         ]);

--- a/test/unitTests/credential/credentialController.test.ts
+++ b/test/unitTests/credential/credentialController.test.ts
@@ -171,12 +171,6 @@ describe('CredentialController', () => {
             await tempCredentialController.signIn('fakedCorrelationId');
             assert.deepStrictEqual(tempEventBus.getEvents(), [new PublicUserSign('SignIn')]);
         });
-
-        it(`Public user sign-out`, async () => {
-            tempEventBus.clear();
-            tempCredentialController.signOut('fakedCorrelationId');
-            assert.deepStrictEqual(tempEventBus.getEvents(), [new PublicUserSign('SignOut')]);
-        });
     });
 
     describe(`User Sign-in With GitHub`, () => {

--- a/test/unitTests/credential/credentialController.test.ts
+++ b/test/unitTests/credential/credentialController.test.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode';
 import assert from 'assert';
-import { CredentialExpired, CredentialReset, EnvironmentChanged, BaseEvent, UserSignInProgress, UserSignInSucceeded, UserSignInFailed, UserSignInTriggered, UserSignOutSucceeded, UserSignOutTriggered, PublicUserSign } from '../../../src/common/loggingEvents';
+import { CredentialExpired, CredentialReset, EnvironmentChanged, BaseEvent, UserSignInProgress, UserSignInSucceeded, UserSignInFailed, UserSignInTriggered, UserSignOutSucceeded, UserSignOutTriggered, PublicUserSignIn } from '../../../src/common/loggingEvents';
 import { EventStream } from '../../../src/common/eventStream';
 import { CredentialController, Credential } from '../../../src/credential/credentialController';
 import { KeyChain } from '../../../src/credential/keyChain';
@@ -156,7 +156,7 @@ describe('CredentialController', () => {
         });
     });
 
-    describe(`Public user`, () => {
+    describe(`Public contributor`, () => {
         const tempEventStream = new EventStream();
         const tempEnvironmentController = <EnvironmentController>{
             env: 'PROD',
@@ -167,9 +167,9 @@ describe('CredentialController', () => {
         };
         const tempCredentialController = new CredentialController(keyChain, tempEventStream, tempEnvironmentController);
         const tempEventBus = new TestEventBus(tempEventStream);
-        it(`Public user sign-in`, async () => {
+        it(`Public contributor sign-in`, async () => {
             await tempCredentialController.signIn('fakedCorrelationId');
-            assert.deepStrictEqual(tempEventBus.getEvents(), [new PublicUserSign('SignIn')]);
+            assert.deepStrictEqual(tempEventBus.getEvents(), [new PublicUserSignIn()]);
         });
     });
 

--- a/test/unitTests/credential/credentialController.test.ts
+++ b/test/unitTests/credential/credentialController.test.ts
@@ -4,7 +4,7 @@ import { CredentialExpired, CredentialReset, EnvironmentChanged, BaseEvent, User
 import { EventStream } from '../../../src/common/eventStream';
 import { CredentialController, Credential } from '../../../src/credential/credentialController';
 import { KeyChain } from '../../../src/credential/keyChain';
-import { EnvironmentController } from '../../../src/common/environmentController';
+import { EnvironmentController, UserType } from '../../../src/common/environmentController';
 import { SinonSandbox, createSandbox, SinonStub } from 'sinon';
 import TestEventBus from '../../utils/testEventBus';
 import { UserInfo, uriHandler } from '../../../src/shared';
@@ -163,7 +163,7 @@ describe('CredentialController', () => {
             docsRepoType: 'GitHub',
             debugMode: false,
             enableSignRecommendHint: true,
-            userType: "undefined"
+            userType: UserType.Unknow
         };
         const tempCredentialController = new CredentialController(keyChain, tempEventStream, tempEnvironmentController);
         const tempEventBus = new TestEventBus(tempEventStream);
@@ -186,7 +186,7 @@ describe('CredentialController', () => {
             docsRepoType: 'GitHub',
             debugMode: false,
             enableSignRecommendHint: true,
-            userType: "public"
+            userType: UserType.PublicContributor
         };
         const tempCredentialController = new CredentialController(keyChain, tempEventStream, tempEnvironmentController);
         const tempEventBus = new TestEventBus(tempEventStream);

--- a/test/unitTests/credential/credentialController.test.ts
+++ b/test/unitTests/credential/credentialController.test.ts
@@ -1,13 +1,13 @@
 import vscode from 'vscode';
 import assert from 'assert';
-import { CredentialExpired, CredentialReset, EnvironmentChanged, BaseEvent, UserSignInProgress, UserSignInSucceeded, UserSignInFailed, UserSignInTriggered, UserSignOutSucceeded, UserSignOutTriggered, CheckIfInternal, PublicUserSignIn, PublicUserSignOut } from '../../../src/common/loggingEvents';
+import { CredentialExpired, CredentialReset, EnvironmentChanged, BaseEvent, UserSignInProgress, UserSignInSucceeded, UserSignInFailed, UserSignInTriggered, UserSignOutSucceeded, UserSignOutTriggered, PublicUserSign } from '../../../src/common/loggingEvents';
 import { EventStream } from '../../../src/common/eventStream';
 import { CredentialController, Credential } from '../../../src/credential/credentialController';
 import { KeyChain } from '../../../src/credential/keyChain';
-import { EnvironmentController, UserType } from '../../../src/common/environmentController';
+import { EnvironmentController } from '../../../src/common/environmentController';
 import { SinonSandbox, createSandbox, SinonStub } from 'sinon';
 import TestEventBus from '../../utils/testEventBus';
-import { UserInfo, uriHandler } from '../../../src/shared';
+import { UserInfo, uriHandler, UserType } from '../../../src/shared';
 import { getFakeEnvironmentController, setupKeyChain, fakedCredential } from '../../utils/faker';
 import extensionConfig from '../../../src/config';
 import { DocsError } from '../../../src/error/docsError';
@@ -156,29 +156,6 @@ describe('CredentialController', () => {
         });
     });
 
-    describe(`Undefined user`, () => {
-        const tempEventStream = new EventStream();
-        const tempEnvironmentController = <EnvironmentController>{
-            env: 'PROD',
-            docsRepoType: 'GitHub',
-            debugMode: false,
-            enableSignRecommendHint: true,
-            userType: UserType.Unknow
-        };
-        const tempCredentialController = new CredentialController(keyChain, tempEventStream, tempEnvironmentController);
-        const tempEventBus = new TestEventBus(tempEventStream);
-        it(`Undefined user sign-in`, async () => {
-            await tempCredentialController.signIn('fakedCorrelationId');
-            assert.deepStrictEqual(tempEventBus.getEvents(), [new CheckIfInternal()]);
-        });
-
-        it(`Undefined user sign-out`, async () => {
-            tempEventBus.clear();
-            tempCredentialController.signOut('fakedCorrelationId');
-            assert.deepStrictEqual(tempEventBus.getEvents(), [new CheckIfInternal()]);
-        });
-    });
-
     describe(`Public user`, () => {
         const tempEventStream = new EventStream();
         const tempEnvironmentController = <EnvironmentController>{
@@ -192,13 +169,13 @@ describe('CredentialController', () => {
         const tempEventBus = new TestEventBus(tempEventStream);
         it(`Public user sign-in`, async () => {
             await tempCredentialController.signIn('fakedCorrelationId');
-            assert.deepStrictEqual(tempEventBus.getEvents(), [new PublicUserSignIn()]);
+            assert.deepStrictEqual(tempEventBus.getEvents(), [new PublicUserSign('SignIn')]);
         });
 
         it(`Public user sign-out`, async () => {
             tempEventBus.clear();
             tempCredentialController.signOut('fakedCorrelationId');
-            assert.deepStrictEqual(tempEventBus.getEvents(), [new PublicUserSignOut()]);
+            assert.deepStrictEqual(tempEventBus.getEvents(), [new PublicUserSign('SignOut')]);
         });
     });
 

--- a/test/unitTests/observers/docsLoggerObserver.test.ts
+++ b/test/unitTests/observers/docsLoggerObserver.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { UserSignInSucceeded, UserSignInProgress, RepositoryInfoRetrieved, BuildProgress, APICallStarted, APICallFailed, DependencyInstallStarted, PackageInstallStarted, DownloadStarted, DownloadSizeObtained, DownloadProgress, DownloadValidating, ZipFileInstalling, PlatformInfoRetrieved, UserSignInFailed, UserSignOutSucceeded, UserSignOutFailed, BuildStarted, BuildSucceeded, BuildCanceled, BuildFailed, DocfxRestoreCompleted, DocfxBuildCompleted, DependencyInstallCompleted, PackageInstallCompleted, PackageInstallAttemptFailed, CancelBuildFailed, BuildTriggered } from '../../../src/common/loggingEvents';
+import { UserSignInSucceeded, UserSignInProgress, RepositoryInfoRetrieved, BuildProgress, APICallStarted, APICallFailed, DependencyInstallStarted, PackageInstallStarted, DownloadStarted, DownloadSizeObtained, DownloadProgress, DownloadValidating, ZipFileInstalling, PlatformInfoRetrieved, UserSignInFailed, UserSignOutSucceeded, UserSignOutFailed, BuildStarted, BuildSucceeded, BuildCanceled, BuildFailed, DocfxRestoreCompleted, DocfxBuildCompleted, DependencyInstallCompleted, PackageInstallCompleted, PackageInstallAttemptFailed, CancelBuildFailed, BuildTriggered, ExtensionActivated, TriggerCommandWithUnkownUserType, PublicUserSignIn } from '../../../src/common/loggingEvents';
 import { DocsLoggerObserver } from '../../../src/observers/docsLoggerObserver';
 import { PlatformInformation } from '../../../src/common/platformInformation';
 import { DocfxExecutionResult } from '../../../src/build/buildResult';
@@ -373,5 +373,35 @@ describe('DocsLoggerObserver', () => {
 
         let expectedOutput = `Platform: faked-platform, faked-arch\n\n`;
         assert.equal(loggerText, expectedOutput);
+    });
+
+    describe('Extension Activated', () => {
+        it(`Extension Activated`, () => {
+            let event = new ExtensionActivated();
+            observer.eventHandler(event);
+
+            let expectedOutput = `Extension activated.\n`;
+            assert.equal(loggerText, expectedOutput);
+        });
+    });
+
+    describe('Command triggered with unknown user type', () => {
+        it(`Command triggered with unknown user type`, () => {
+            let event = new TriggerCommandWithUnkownUserType();
+            observer.eventHandler(event);
+
+            let expectedOutput = `Command triggered when user type is unknown.\n`;
+            assert.equal(loggerText, expectedOutput);
+        });
+    });
+
+    describe('Public user sign in', () => {
+        it(`Public user sign in`, () => {
+            let event = new PublicUserSignIn();
+            observer.eventHandler(event);
+
+            let expectedOutput = `Sign in failed: Sign in is only available for Microsoft employees.\n`;
+            assert.equal(loggerText, expectedOutput);
+        });
     });
 });

--- a/test/unitTests/observers/infoMessageObserver.test.ts
+++ b/test/unitTests/observers/infoMessageObserver.test.ts
@@ -122,7 +122,7 @@ describe('InfoMessageObserver', () => {
         it(`EnableSignRecommendHint as true`, () => {
             let event = new BuildTriggered(`fakedCorrelationId`, false);
             observer.eventHandler(event);
-            assert.equal(messageToShow, `[Docs Validation] If you are a Microsoft internal employee, you are recommended to login to the Docs system by clicking 'Docs Validation' in the status bar and 'Sign-in' in command palette, or you may get some validation errors if some non-live data (e.g. UID, moniker) has been used.`);
+            assert.equal(messageToShow, `[Docs Validation] If you are a Microsoft employee, you are recommended to login to the Docs system by clicking 'Docs Validation' in the status bar and 'Sign-in' in command palette, or you may get some validation errors if some non-live data (e.g. UID, moniker) has been used.`);
             assert.deepEqual(messageActions[0].title, "Don't show this message again");
         });
     });

--- a/test/unitTests/observers/infoMessageObserver.test.ts
+++ b/test/unitTests/observers/infoMessageObserver.test.ts
@@ -1,11 +1,11 @@
 import assert from 'assert';
 import vscode, { MessageItem } from 'vscode';
-import { UserSignInCompleted, UserSignOutCompleted, BuildTriggered, BuildCompleted } from '../../../src/common/loggingEvents';
+import { UserSignInCompleted, UserSignOutCompleted, BuildTriggered, BuildCompleted, ExtensionActivated } from '../../../src/common/loggingEvents';
 import { getFakeEnvironmentController } from '../../utils/faker';
 import { EnvironmentController } from '../../../src/common/environmentController';
 import { InfoMessageObserver } from '../../../src/observers/infoMessageObserver';
 import { SinonSandbox, createSandbox } from 'sinon';
-import { MessageAction } from '../../../src/shared';
+import { MessageAction, UserType } from '../../../src/shared';
 import { DocfxExecutionResult } from '../../../src/build/buildResult';
 
 describe('InfoMessageObserver', () => {
@@ -149,5 +149,26 @@ describe('InfoMessageObserver', () => {
             assert.equal(messageToShow, undefined);
             assert.deepEqual(messageActions, []);
         });
+    });
+
+    describe(`Extension activated`, () => {
+        beforeEach(() => {
+            messageToShow = undefined;
+            messageActions = [];
+        });
+
+        it(`User type unknown`, () => {
+            sinon.stub(environmentController, "userType").get(function getUserType() {
+                return UserType.Unknown;
+            });
+            let event = new ExtensionActivated();
+            observer.eventHandler(event);
+            assert.equal(messageToShow, `[Docs Validation] Are you a Microsoft employee or a public contributor? We need this information to provide a better validation experience. ` +
+                `You can change your selection later if needed in the extension settings (Docs validation -> User type).`);
+            assert.deepEqual(messageActions[0].title, "Microsoft employee");
+            assert.deepEqual(messageActions[1].title, "Public contributor");
+        });
+
+
     });
 });

--- a/test/unitTests/observers/infoMessageObserver.test.ts
+++ b/test/unitTests/observers/infoMessageObserver.test.ts
@@ -122,7 +122,7 @@ describe('InfoMessageObserver', () => {
         it(`EnableSignRecommendHint as true`, () => {
             let event = new BuildTriggered(`fakedCorrelationId`, false);
             observer.eventHandler(event);
-            assert.equal(messageToShow, `[Docs Validation] If you are a Microsoft internal user, you are recommended to login to the Docs system by clicking 'Docs Validation' in the status bar and 'Sign-in' in command palette, or you may get some validation errors if some non-live data (e.g. UID, moniker) has been used.`);
+            assert.equal(messageToShow, `[Docs Validation] If you are a Microsoft internal employee, you are recommended to login to the Docs system by clicking 'Docs Validation' in the status bar and 'Sign-in' in command palette, or you may get some validation errors if some non-live data (e.g. UID, moniker) has been used.`);
             assert.deepEqual(messageActions[0].title, "Don't show this message again");
         });
     });

--- a/test/unitTests/observers/infoMessageObserver.test.ts
+++ b/test/unitTests/observers/infoMessageObserver.test.ts
@@ -168,7 +168,5 @@ describe('InfoMessageObserver', () => {
             assert.deepEqual(messageActions[0].title, "Microsoft employee");
             assert.deepEqual(messageActions[1].title, "Public contributor");
         });
-
-
     });
 });

--- a/test/unitTests/observers/infoMessageObserver.test.ts
+++ b/test/unitTests/observers/infoMessageObserver.test.ts
@@ -91,7 +91,7 @@ describe('InfoMessageObserver', () => {
             let event = new UserSignOutCompleted(`fakedCorrelationId`, true);
             observer.eventHandler(event);
             assert.equal(messageToShow, `[Docs Validation] Successfully signed out!`);
-            assert.deepEqual(messageActions, [undefined]);
+            assert.deepEqual(messageActions, []);
         });
     });
 

--- a/test/utils/faker.ts
+++ b/test/utils/faker.ts
@@ -18,6 +18,7 @@ export function getFakeEnvironmentController(docsRepoType: DocsRepoType = 'GitHu
         docsRepoType: docsRepoType || 'GitHub',
         debugMode: false,
         enableSignRecommendHint: true,
+        userType: undefined
     };
 }
 

--- a/test/utils/faker.ts
+++ b/test/utils/faker.ts
@@ -18,7 +18,7 @@ export function getFakeEnvironmentController(docsRepoType: DocsRepoType = 'GitHu
         docsRepoType: docsRepoType || 'GitHub',
         debugMode: false,
         enableSignRecommendHint: true,
-        userType: UserType.MicrosoftInternalEmployee
+        userType: UserType.MicrosoftEmployee
     };
 }
 

--- a/test/utils/faker.ts
+++ b/test/utils/faker.ts
@@ -1,9 +1,9 @@
 import path from 'path';
-import { EnvironmentController, UserType } from '../../src/common/environmentController';
+import { EnvironmentController } from '../../src/common/environmentController';
 import { AbsolutePathPackage } from '../../src/dependency/package';
 import { SinonSandbox } from 'sinon';
 import { KeyChain } from '../../src/credential/keyChain';
-import { UserInfo, DocsRepoType } from '../../src/shared';
+import { UserInfo, DocsRepoType, UserType } from '../../src/shared';
 import { Credential } from '../../src/credential/credentialController';
 import { ExtensionContext } from '../../src/extensionContext';
 import { PlatformInformation } from '../../src/common/platformInformation';

--- a/test/utils/faker.ts
+++ b/test/utils/faker.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { EnvironmentController } from '../../src/common/environmentController';
+import { EnvironmentController, UserType } from '../../src/common/environmentController';
 import { AbsolutePathPackage } from '../../src/dependency/package';
 import { SinonSandbox } from 'sinon';
 import { KeyChain } from '../../src/credential/keyChain';
@@ -18,7 +18,7 @@ export function getFakeEnvironmentController(docsRepoType: DocsRepoType = 'GitHu
         docsRepoType: docsRepoType || 'GitHub',
         debugMode: false,
         enableSignRecommendHint: true,
-        userType: "internal"
+        userType: UserType.InternalEmployee
     };
 }
 

--- a/test/utils/faker.ts
+++ b/test/utils/faker.ts
@@ -18,7 +18,7 @@ export function getFakeEnvironmentController(docsRepoType: DocsRepoType = 'GitHu
         docsRepoType: docsRepoType || 'GitHub',
         debugMode: false,
         enableSignRecommendHint: true,
-        userType: undefined
+        userType: "internal"
     };
 }
 

--- a/test/utils/faker.ts
+++ b/test/utils/faker.ts
@@ -18,7 +18,7 @@ export function getFakeEnvironmentController(docsRepoType: DocsRepoType = 'GitHu
         docsRepoType: docsRepoType || 'GitHub',
         debugMode: false,
         enableSignRecommendHint: true,
-        userType: UserType.InternalEmployee
+        userType: UserType.MicrosoftInternalEmployee
     };
 }
 


### PR DESCRIPTION
**Story Link**: [AB#336932](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/336932)

**Description**
After this change, users' experience will be:

1. Seeing a pop-up window after the extension is activated, suggesting them to choose over internal user and public user. This window will continue showing up and stop the users doing anything until they make a choice.
2. For public users, they won't see any sign in option in the quick pick menu. If they enter sign-in/ sign out in the command palette, they will see a message indicating that this is only for internal users.
3. For internal users, they are blocked to use validation function before signing in.

**TODO**
1. Remove the window that suggest internal users to sign in, and all the related logic.
2. Unit test.