### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Changed
 
-- Add user role (Microsoft employee/ public contributor) checking.
-- Use latest docfx: 3.0.0-beta1.599+2532899be6.
-- Remove `PullRequestOnly` messages from diagnostic channel.
+- Add user role (Microsoft employee/ public contributor) checking. (#157)
+- Use latest docfx: 3.0.0-beta1.599+2532899be6. (#156)
+- Remove `PullRequestOnly` messages from diagnostic channel. (#152)
 
 ## 0.2.2 (November 4, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - Add user role (Microsoft employee/ public contributor) checking.
+- Use latest docfx: 3.0.0-beta1.599+2532899be6.
+- Remove `PullRequestOnly` messages from diagnostic channel.
 
 ## 0.2.2 (November 4, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.2.3 (December 3, 2020)
+
+### Changed
+
+- Add user role (Microsoft employee/ public contributor) checking.
+
 ## 0.2.2 (November 4, 2020)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "docs-build",
   "displayName": "docs-validation",
   "description": "Docs Validation Extension which enables you to run build validation on a Docs conceptual or Learn repo at authoring time in VS Code",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "vscode": "^1.40.0"
   },


### PR DESCRIPTION
release v0.2.3

- Add user role (Microsoft employee/ public contributor) checking.
- Use latest docfx: 3.0.0-beta1.599+2532899be6.
- Remove `PullRequestOnly` messages from diagnostic channel.