### PR TITLE
chore: Move linting to GitHub Action

### DIFF
--- a/.github/workflows/ts-lint.yml
+++ b/.github/workflows/ts-lint.yml
@@ -1,0 +1,17 @@
+name: Lint TS
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+
+    - run: npm ci
+
+    - run: npm run lint

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -46,14 +46,6 @@ steps:
   inputs:
     verbose: false
 
-- task: Npm@1
-  displayName: 'Lint'
-  inputs:
-    command: custom
-    verbose: false
-    customCommand: run lint
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-
 - bash: |
     npm run test
   displayName: Run Test(Mac)


### PR DESCRIPTION
~~I used `path` filters to only run on affected files, so this won't work as a "required" GitHub Check. I could change that if you want it to be required~~
Swapped to a job that cancels the `lint` if affected files aren't changed so it works as a `Required` check