### PR TITLE
Report diagnostics without source info on `.openpublishing.publish.config.json`

### DIFF
--- a/src/build/reportGenerator.ts
+++ b/src/build/reportGenerator.ts
@@ -54,15 +54,15 @@ export function visualizeBuildReport(repositoryPath: string, logPath: string, di
             }
 
             const range = new vscode.Range(
-                convertToZeroBased(reportItem.line ? reportItem.line : 0),
-                convertToZeroBased(reportItem.column ? reportItem.column : 0),
-                convertToZeroBased(reportItem.end_line ? reportItem.end_line : 0),
-                convertToZeroBased(reportItem.end_column ? reportItem.end_column : 0));
+                convertToZeroBased(reportItem.line ?? 0),
+                convertToZeroBased(reportItem.column ?? 0),
+                convertToZeroBased(reportItem.end_line ?? 0),
+                convertToZeroBased(reportItem.end_column ?? 0));
             const diagnostic = new vscode.Diagnostic(range, reportItem.message, severityMap.get(reportItem.message_severity));
             diagnostic.code = reportItem.code;
             diagnostic.source = EXTENSION_DIAGNOSTIC_SOURCE;
 
-            const sourceFile = reportItem.file ? reportItem.file : configFile;
+            const sourceFile = reportItem.file ?? configFile;
             if (!diagnosticsSet.has(sourceFile)) {
                 diagnosticsSet.set(sourceFile, {
                     uri: vscode.Uri.file(path.resolve(repositoryPath, sourceFile)),

--- a/src/build/reportGenerator.ts
+++ b/src/build/reportGenerator.ts
@@ -29,6 +29,8 @@ const severityMap = new Map<MessageSeverity, vscode.DiagnosticSeverity>([
     ["suggestion", vscode.DiagnosticSeverity.Information]
 ]);
 
+const configFile = '.openpublishing.publish.config.json';
+
 type MessageSeverity = "error" | "warning" | "info" | "suggestion";
 type LogItemType = 'system' | ' user';
 
@@ -47,23 +49,20 @@ export function visualizeBuildReport(repositoryPath: string, logPath: string, di
         report.forEach(item => {
             const reportItem = <ReportItem>JSON.parse(item);
 
-            if (!reportItem.file) {
-                return;
-            }
             if (reportItem.pull_request_only) {
                 return;
             }
 
             const range = new vscode.Range(
-                convertToZeroBased(reportItem.line),
-                convertToZeroBased(reportItem.column),
-                convertToZeroBased(reportItem.end_line),
-                convertToZeroBased(reportItem.end_column));
+                convertToZeroBased(reportItem.line ? reportItem.line : 0),
+                convertToZeroBased(reportItem.column ? reportItem.column : 0),
+                convertToZeroBased(reportItem.end_line ? reportItem.end_line : 0),
+                convertToZeroBased(reportItem.end_column ? reportItem.end_column : 0));
             const diagnostic = new vscode.Diagnostic(range, reportItem.message, severityMap.get(reportItem.message_severity));
             diagnostic.code = reportItem.code;
             diagnostic.source = EXTENSION_DIAGNOSTIC_SOURCE;
 
-            const sourceFile = reportItem.file;
+            const sourceFile = reportItem.file ? reportItem.file : configFile;
             if (!diagnosticsSet.has(sourceFile)) {
                 diagnosticsSet.set(sourceFile, {
                     uri: vscode.Uri.file(path.resolve(repositoryPath, sourceFile)),


### PR DESCRIPTION
Within the scope of the tast: [AB#358402](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/358402). It's better showing diagnostics with no source file for full-repo validation as well.
![image](https://user-images.githubusercontent.com/74176112/104413755-e1240400-55a9-11eb-83d6-286cdca8e158.png)
