### PR TITLE
Send SessionInfo telemetry event after extension activated

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -93,7 +93,7 @@
                 "updateRuntimeDependencies"
             ],
             "env": {
-                "DOCFX_VERSION": "3.0.0-beta1.715+39a49927fc"
+                "DOCFX_VERSION": "3.0.0-beta1.739+f35b8c38de"
             },
             "cwd": "${workspaceFolder}"
         }

--- a/package.json
+++ b/package.json
@@ -223,21 +223,21 @@
       "id": "docfx-win7-x64",
       "name": "docfx",
       "description": "DocFX for Windows (x64)",
-      "url": "https://opsbuildk8sprod.blob.core.windows.net/docfx-bin/docfx-win7-x64-3.0.0-beta1.715+39a49927fc.zip",
+      "url": "https://opsbuildk8sprod.blob.core.windows.net/docfx-bin/docfx-win7-x64-3.0.0-beta1.739+f35b8c38de.zip",
       "binary": "docfx.exe",
       "installPath": ".docfx",
       "rid": "win7-x64",
-      "integrity": "46A1941FC1EE60464FBF7B3E0C0FAB7DACBD67ABA57EFB5FA2BE909CC0C384A5"
+      "integrity": "6485883D9378DEF59E5590B409B9478B282E1604DD8EC1D298702AEDCA450349"
     },
     {
       "id": "docfx-osx-x64",
       "name": "docfx",
       "description": "DocFX for OSX(x64)",
-      "url": "https://opsbuildk8sprod.blob.core.windows.net/docfx-bin/docfx-osx-x64-3.0.0-beta1.715+39a49927fc.zip",
+      "url": "https://opsbuildk8sprod.blob.core.windows.net/docfx-bin/docfx-osx-x64-3.0.0-beta1.739+f35b8c38de.zip",
       "binary": "./docfx",
       "installPath": ".docfx",
       "rid": "osx-x64",
-      "integrity": "511E2A7A89AF086EE50CD1FEF7FF76F0D3B7FD3488065A0CE808855ECC473AE4"
+      "integrity": "85C2C7D0E03D4BCF10018482F59954249D5B6F418D3AEA439A0E63F0642A6487"
     }
   ]
 }

--- a/src/build/buildExecutor.ts
+++ b/src/build/buildExecutor.ts
@@ -195,7 +195,8 @@ export class BuildExecutor implements Disposable {
         const envs: any = {
             'DOCFX_CORRELATION_ID': correlationId,
             'DOCFX_REPOSITORY_URL': input.originalRepositoryUrl,
-            'DOCS_ENVIRONMENT': this._environmentController.env
+            'DOCS_ENVIRONMENT': this._environmentController.env,
+            'DOCS_SESSION_ID': vscode.env.sessionId
         };
 
         const isPublicUser = this._environmentController.userType === UserType.PublicContributor;
@@ -226,7 +227,6 @@ export class BuildExecutor implements Disposable {
             };
         }
         envs["DOCFX_HTTP"] = JSON.stringify(secrets);
-        envs["SESSION_ID"] = vscode.env.sessionId;
 
         return <BuildParameters>{
             envs,

--- a/src/build/buildExecutor.ts
+++ b/src/build/buildExecutor.ts
@@ -1,6 +1,6 @@
 import { ChildProcess } from 'child_process';
 import { Duplex } from 'stream';
-import { Disposable } from 'vscode';
+import vscode, { Disposable } from 'vscode';
 import {
     LanguageClient,
     StreamInfo
@@ -9,11 +9,11 @@ import WebSocket from 'ws';
 
 import { EnvironmentController } from '../common/environmentController';
 import { EventStream } from '../common/eventStream';
-import { DocfxBuildCompleted, DocfxBuildStarted, DocfxRestoreCompleted,DocfxRestoreStarted } from '../common/loggingEvents';
+import { DocfxBuildCompleted, DocfxBuildStarted, DocfxRestoreCompleted, DocfxRestoreStarted } from '../common/loggingEvents';
 import { PlatformInformation } from '../common/platformInformation';
 import config from '../config';
 import { CredentialExpiryHandler } from '../credential/credentialExpiryHandler';
-import { AbsolutePathPackage,Package } from '../dependency/package';
+import { AbsolutePathPackage, Package } from '../dependency/package';
 import { DocsError } from '../error/docsError';
 import { ErrorCode } from '../error/errorCode';
 import { ExtensionContext } from '../extensionContext';
@@ -22,7 +22,7 @@ import TelemetryReporter from '../telemetryReporter';
 import { executeDocfx } from '../utils/childProcessUtils';
 import { basicAuth, getDurationInSeconds, killProcessTree } from '../utils/utils';
 import { BuildInput } from './buildInput';
-import { BuildResult,DocfxExecutionResult } from './buildResult';
+import { BuildResult, DocfxExecutionResult } from './buildResult';
 
 interface BuildParameters {
     restoreCommand: string;
@@ -226,6 +226,7 @@ export class BuildExecutor implements Disposable {
             };
         }
         envs["DOCFX_HTTP"] = JSON.stringify(secrets);
+        envs["SESSION_ID"] = vscode.env.sessionId;
 
         return <BuildParameters>{
             envs,

--- a/src/build/buildExecutor.ts
+++ b/src/build/buildExecutor.ts
@@ -196,7 +196,7 @@ export class BuildExecutor implements Disposable {
             'DOCFX_CORRELATION_ID': correlationId,
             'DOCFX_REPOSITORY_URL': input.originalRepositoryUrl,
             'DOCS_ENVIRONMENT': this._environmentController.env,
-            'DOCS_SESSION_ID': vscode.env.sessionId
+            'DOCFX_SESSION_ID': vscode.env.sessionId
         };
 
         const isPublicUser = this._environmentController.userType === UserType.PublicContributor;

--- a/src/common/loggingEvents.ts
+++ b/src/common/loggingEvents.ts
@@ -2,7 +2,7 @@ import { BuildInput } from '../build/buildInput';
 import { BuildResult, DocfxExecutionResult } from '../build/buildResult';
 import { Credential } from '../credential/credentialController';
 import { AbsolutePathPackage } from '../dependency/package';
-import { Environment, SignInReason } from '../shared';
+import { Environment, SignInReason, UserType } from '../shared';
 import { EventType } from './eventType';
 import { PlatformInformation } from './platformInformation';
 
@@ -255,6 +255,7 @@ export class TriggerCommandWithUnknownUserType implements BaseEvent {
 
 export class ExtensionActivated implements BaseEvent {
     type = EventType.ExtensionActivated;
+    constructor(public userType: UserType, public sessionId: string) { }
 }
 
 export class StartLanguageServerCompleted implements BaseEvent {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,7 +136,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
 
     // eslint-disable-next-line promise/catch-or-return, promise/always-return
     credentialInitialPromise.then(() => {
-        eventStream.post(new ExtensionActivated());
+        eventStream.post(new ExtensionActivated(environmentController.userType, vscode.env.sessionId));
     });
 
     return {

--- a/src/observers/telemetryObserver.ts
+++ b/src/observers/telemetryObserver.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { BuildType } from '../build/buildInput';
 import { DocfxExecutionResult } from '../build/buildResult';
 import { EventType } from '../common/eventType';
-import { BaseEvent, BuildCompleted, BuildFailed, BuildSucceeded, BuildTriggered, CancelBuildCompleted, CancelBuildTriggered, DependencyInstallCompleted, DependencyInstallStarted, DocfxRestoreCompleted,LearnMoreClicked, PackageInstallAttemptFailed, PackageInstallCompleted, QuickPickCommandSelected, QuickPickTriggered, UserSignInCompleted, UserSignInFailed, UserSignInSucceeded, UserSignInTriggered, UserSignOutCompleted, UserSignOutTriggered } from '../common/loggingEvents';
+import { BaseEvent, BuildCompleted, BuildFailed, BuildSucceeded, BuildTriggered, CancelBuildCompleted, CancelBuildTriggered, DependencyInstallCompleted, DependencyInstallStarted, DocfxRestoreCompleted, ExtensionActivated, LearnMoreClicked, PackageInstallAttemptFailed, PackageInstallCompleted, QuickPickCommandSelected, QuickPickTriggered, UserSignInCompleted, UserSignInFailed, UserSignInSucceeded, UserSignInTriggered, UserSignOutCompleted, UserSignOutTriggered } from '../common/loggingEvents';
 import { DocsError } from '../error/docsError';
 import { DocsRepoType } from '../shared';
 import TelemetryReporter from '../telemetryReporter';
@@ -64,6 +64,10 @@ export class TelemetryObserver {
                 break;
             case EventType.LearnMoreClicked:
                 this.handleLearnMoreClicked(<LearnMoreClicked>event);
+                break;
+            // Other
+            case EventType.ExtensionActivated:
+                this.handleExtensionActivated(<ExtensionActivated>event);
                 break;
         }
     }
@@ -280,6 +284,16 @@ export class TelemetryObserver {
             {
                 CorrelationId: event.correlationId,
                 ErrorCode: event.diagnosticErrorCode
+            }
+        );
+    }
+
+    private handleExtensionActivated(event: ExtensionActivated) {
+        this._reporter.sendTelemetryEvent(
+            'SessionInfo',
+            {
+                SessionId: event.sessionId,
+                UserRole: event.userType
             }
         );
     }

--- a/test/unitTests/build/buildExecutor.test.ts
+++ b/test/unitTests/build/buildExecutor.test.ts
@@ -190,7 +190,7 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`,
-                        DOCS_SESSION_ID: fakeSessionId
+                        DOCFX_SESSION_ID: fakeSessionId
 
                     }
                 },
@@ -202,7 +202,7 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`,
-                        DOCS_SESSION_ID: fakeSessionId
+                        DOCFX_SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -283,7 +283,7 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`,
-                        DOCS_SESSION_ID: fakeSessionId
+                        DOCFX_SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -358,7 +358,7 @@ describe('BuildExecutor', () => {
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_REPOSITORY_BRANCH: 'master',
                         DOCFX_HTTP: '{}',
-                        DOCS_SESSION_ID: fakeSessionId
+                        DOCFX_SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -415,7 +415,7 @@ describe('BuildExecutor', () => {
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_REPOSITORY_BRANCH: 'master',
                         DOCFX_HTTP: '{}',
-                        DOCS_SESSION_ID: fakeSessionId
+                        DOCFX_SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -442,7 +442,7 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"fakeToken"}}}`,
-                        DOCS_SESSION_ID: fakeSessionId
+                        DOCFX_SESSION_ID: fakeSessionId
                     }
                 }
             ]);

--- a/test/unitTests/build/buildExecutor.test.ts
+++ b/test/unitTests/build/buildExecutor.test.ts
@@ -190,7 +190,7 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`,
-                        SESSION_ID: fakeSessionId
+                        DOCS_SESSION_ID: fakeSessionId
 
                     }
                 },
@@ -202,7 +202,7 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`,
-                        SESSION_ID: fakeSessionId
+                        DOCS_SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -283,7 +283,7 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`,
-                        SESSION_ID: fakeSessionId
+                        DOCS_SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -358,7 +358,7 @@ describe('BuildExecutor', () => {
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_REPOSITORY_BRANCH: 'master',
                         DOCFX_HTTP: '{}',
-                        SESSION_ID: fakeSessionId
+                        DOCS_SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -415,7 +415,7 @@ describe('BuildExecutor', () => {
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_REPOSITORY_BRANCH: 'master',
                         DOCFX_HTTP: '{}',
-                        SESSION_ID: fakeSessionId
+                        DOCS_SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -442,7 +442,7 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"fakeToken"}}}`,
-                        SESSION_ID: fakeSessionId
+                        DOCS_SESSION_ID: fakeSessionId
                     }
                 }
             ]);

--- a/test/unitTests/build/buildExecutor.test.ts
+++ b/test/unitTests/build/buildExecutor.test.ts
@@ -4,22 +4,23 @@ import path from 'path';
 import { Subscription } from 'rxjs';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { setTimeout } from 'timers';
+import vscode from 'vscode';
 import { LanguageClient } from "vscode-languageclient/node";
 
 import { BuildExecutor } from '../../../src/build/buildExecutor';
-import { BuildInput,BuildType } from '../../../src/build/buildInput';
-import { BuildResult,DocfxExecutionResult } from '../../../src/build/buildResult';
+import { BuildInput, BuildType } from '../../../src/build/buildInput';
+import { BuildResult, DocfxExecutionResult } from '../../../src/build/buildResult';
 import { EnvironmentController } from '../../../src/common/environmentController';
 import { EventStream } from '../../../src/common/eventStream';
 import { EventType } from '../../../src/common/eventType';
-import { DocfxBuildCompleted,DocfxBuildStarted, DocfxRestoreCompleted, DocfxRestoreStarted } from '../../../src/common/loggingEvents';
+import { DocfxBuildCompleted, DocfxBuildStarted, DocfxRestoreCompleted, DocfxRestoreStarted } from '../../../src/common/loggingEvents';
 import { PlatformInformation } from '../../../src/common/platformInformation';
 import { CredentialExpiryHandler } from '../../../src/credential/credentialExpiryHandler';
 import { OP_BUILD_USER_TOKEN_HEADER_NAME, UserType } from '../../../src/shared';
 import TelemetryReporter from '../../../src/telemetryReporter';
 import * as childProcessUtil from '../../../src/utils/childProcessUtils';
 import * as utils from '../../../src/utils/utils';
-import { defaultLogPath, defaultOutputPath, fakedBuildInput, fakedExtensionContext, getFakedNonWindowsPlatformInformation, getFakedTelemetryReporter, getFakedWindowsPlatformInformation, getFakeEnvironmentController, publicTemplateURL,setTelemetryUserOptInToFalse, setTelemetryUserOptInToTrue, tempFolder } from '../../utils/faker';
+import { defaultLogPath, defaultOutputPath, fakedBuildInput, fakedExtensionContext, getFakedNonWindowsPlatformInformation, getFakedTelemetryReporter, getFakedWindowsPlatformInformation, getFakeEnvironmentController, publicTemplateURL, setTelemetryUserOptInToFalse, setTelemetryUserOptInToTrue, tempFolder } from '../../utils/faker';
 import TestEventBus from '../../utils/testEventBus';
 
 describe('BuildExecutor', () => {
@@ -38,6 +39,8 @@ describe('BuildExecutor', () => {
     let executedCommands: string[];
     let executedOptions: cp.ExecOptions[];
     let killProcessTreeFuncCalled: boolean;
+
+    const fakeSessionId = 'fakeSessionId';
 
     before(() => {
         eventStream = new EventStream();
@@ -155,6 +158,9 @@ describe('BuildExecutor', () => {
     describe('Build', () => {
         before(() => {
             mockExecuteDocfx(0, 0);
+            sinon.stub(vscode.env, 'sessionId').get(function getSessionId() {
+                return fakeSessionId;
+            });
         });
 
         beforeEach(() => {
@@ -183,7 +189,9 @@ describe('BuildExecutor', () => {
                         DOCFX_CORRELATION_ID: 'fakedCorrelationId',
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
-                        DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`
+                        DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`,
+                        SESSION_ID: fakeSessionId
+
                     }
                 },
                 {
@@ -193,7 +201,8 @@ describe('BuildExecutor', () => {
                         DOCFX_CORRELATION_ID: 'fakedCorrelationId',
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
-                        DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`
+                        DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`,
+                        SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -273,7 +282,8 @@ describe('BuildExecutor', () => {
                         DOCFX_CORRELATION_ID: 'fakedCorrelationId',
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
-                        DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`
+                        DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"faked-build-token"}}}`,
+                        SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -347,7 +357,8 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_REPOSITORY_BRANCH: 'master',
-                        DOCFX_HTTP: '{}'
+                        DOCFX_HTTP: '{}',
+                        SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -403,7 +414,8 @@ describe('BuildExecutor', () => {
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
                         DOCFX_REPOSITORY_BRANCH: 'master',
-                        DOCFX_HTTP: '{}'
+                        DOCFX_HTTP: '{}',
+                        SESSION_ID: fakeSessionId
                     }
                 }
             ]);
@@ -429,7 +441,8 @@ describe('BuildExecutor', () => {
                         DOCFX_CORRELATION_ID: undefined,
                         DOCFX_REPOSITORY_URL: 'https://faked.original.repository',
                         DOCS_ENVIRONMENT: 'PROD',
-                        DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"fakeToken"}}}`
+                        DOCFX_HTTP: `{"https://op-build-prod.azurewebsites.net":{"headers":{"${OP_BUILD_USER_TOKEN_HEADER_NAME}":"fakeToken"}}}`,
+                        SESSION_ID: fakeSessionId
                     }
                 }
             ]);

--- a/test/unitTests/build/languageServerManager.test.ts
+++ b/test/unitTests/build/languageServerManager.test.ts
@@ -15,6 +15,7 @@ describe('LanguageServerManager', () => {
             return;
         }
     };
+    const fakeSessionId = 'fakeSessionId';
     const spyStartLanguageServer: SinonSpy = sinon.spy(fakeBuildController, 'startDocfxLanguageServer');
 
     let manager: LanguageServerManager;
@@ -35,7 +36,7 @@ describe('LanguageServerManager', () => {
             enableAutomaticRealTimeValidation: false
         },
             fakeBuildController);
-        manager.eventHandler(new ExtensionActivated());
+        manager.eventHandler(new ExtensionActivated(UserType.MicrosoftEmployee, fakeSessionId));
         assert(spyStartLanguageServer.notCalled);
     });
 
@@ -48,7 +49,7 @@ describe('LanguageServerManager', () => {
             enableAutomaticRealTimeValidation: true
         },
             fakeBuildController);
-        manager.eventHandler(new ExtensionActivated());
+        manager.eventHandler(new ExtensionActivated(UserType.Unknown, fakeSessionId));
         assert(spyStartLanguageServer.notCalled);
     });
 
@@ -61,7 +62,7 @@ describe('LanguageServerManager', () => {
             enableAutomaticRealTimeValidation: true
         },
             fakeBuildController);
-        manager.eventHandler(new ExtensionActivated());
+        manager.eventHandler(new ExtensionActivated(UserType.PublicContributor, fakeSessionId));
         assert(spyStartLanguageServer.calledOnce);
     });
 

--- a/test/unitTests/observers/docsLoggerObserver.test.ts
+++ b/test/unitTests/observers/docsLoggerObserver.test.ts
@@ -2,12 +2,13 @@ import assert from 'assert';
 
 import { DocfxExecutionResult } from '../../../src/build/buildResult';
 import { ILogger } from '../../../src/common/logger';
-import { APICallFailed, APICallStarted, BuildCanceled, BuildFailed, BuildProgress, BuildStarted, BuildSucceeded, BuildTriggered, CancelBuildFailed, DependencyInstallCompleted, DependencyInstallStarted, DocfxBuildCompleted, DocfxRestoreCompleted, DownloadProgress, DownloadSizeObtained, DownloadStarted, DownloadValidating, ExtensionActivated, PackageInstallAttemptFailed, PackageInstallCompleted, PackageInstallStarted, PlatformInfoRetrieved, PublicContributorSignIn, RepositoryInfoRetrieved, StartLanguageServerCompleted,TriggerCommandWithUnknownUserType, UserSignInFailed, UserSignInProgress, UserSignInSucceeded, UserSignOutFailed, UserSignOutSucceeded, ZipFileInstalling } from '../../../src/common/loggingEvents';
+import { APICallFailed, APICallStarted, BuildCanceled, BuildFailed, BuildProgress, BuildStarted, BuildSucceeded, BuildTriggered, CancelBuildFailed, DependencyInstallCompleted, DependencyInstallStarted, DocfxBuildCompleted, DocfxRestoreCompleted, DownloadProgress, DownloadSizeObtained, DownloadStarted, DownloadValidating, ExtensionActivated, PackageInstallAttemptFailed, PackageInstallCompleted, PackageInstallStarted, PlatformInfoRetrieved, PublicContributorSignIn, RepositoryInfoRetrieved, StartLanguageServerCompleted, TriggerCommandWithUnknownUserType, UserSignInFailed, UserSignInProgress, UserSignInSucceeded, UserSignOutFailed, UserSignOutSucceeded, ZipFileInstalling } from '../../../src/common/loggingEvents';
 import { PlatformInformation } from '../../../src/common/platformInformation';
 import { DocsError } from '../../../src/error/docsError';
 import { ErrorCode } from '../../../src/error/errorCode';
 import { DocsLoggerObserver } from '../../../src/observers/docsLoggerObserver';
-import { fakedCredential,fakedPackage } from '../../utils/faker';
+import { UserType } from '../../../src/shared';
+import { fakedCredential, fakedPackage } from '../../utils/faker';
 
 describe('DocsLoggerObserver', () => {
     let loggerText: string;
@@ -380,7 +381,7 @@ describe('DocsLoggerObserver', () => {
 
     describe('Extension Activated', () => {
         it(`Extension Activated`, () => {
-            const event = new ExtensionActivated();
+            const event = new ExtensionActivated(UserType.MicrosoftEmployee, 'fakeSessionId');
             observer.eventHandler(event);
 
             const expectedOutput = `Extension activated.\n`;

--- a/test/unitTests/observers/infoMessageObserver.test.ts
+++ b/test/unitTests/observers/infoMessageObserver.test.ts
@@ -1,10 +1,10 @@
 import assert from 'assert';
-import { createSandbox,SinonSandbox } from 'sinon';
+import { createSandbox, SinonSandbox } from 'sinon';
 import vscode, { MessageItem } from 'vscode';
 
 import { DocfxExecutionResult } from '../../../src/build/buildResult';
 import { EnvironmentController } from '../../../src/common/environmentController';
-import { BuildCompleted, BuildTriggered, ExtensionActivated,UserSignInCompleted, UserSignOutCompleted } from '../../../src/common/loggingEvents';
+import { BuildCompleted, BuildTriggered, ExtensionActivated, UserSignInCompleted, UserSignOutCompleted } from '../../../src/common/loggingEvents';
 import { InfoMessageObserver } from '../../../src/observers/infoMessageObserver';
 import { MessageAction, UserType } from '../../../src/shared';
 import { getFakeEnvironmentController } from '../../utils/faker';
@@ -140,6 +140,7 @@ describe('InfoMessageObserver', () => {
     });
 
     describe(`Extension activated`, () => {
+        const fakeSessionId = 'fakeSessionId';
         beforeEach(() => {
             messageToShow = undefined;
             messageActions = [];
@@ -149,7 +150,7 @@ describe('InfoMessageObserver', () => {
             sinon.stub(environmentController, "userType").get(function getUserType() {
                 return UserType.Unknown;
             });
-            const event = new ExtensionActivated();
+            const event = new ExtensionActivated(environmentController.userType, fakeSessionId);
             observer.eventHandler(event);
             assert.equal(messageToShow, `[Docs Validation] Are you a Microsoft employee or a public contributor? We need this information to provide a better validation experience. ` +
                 `You can change your selection later if needed in the extension settings (Docs validation -> User type).`);
@@ -161,7 +162,7 @@ describe('InfoMessageObserver', () => {
             sinon.stub(environmentController, "userType").get(function getUserType() {
                 return UserType.MicrosoftEmployee;
             });
-            const event = new ExtensionActivated();
+            const event = new ExtensionActivated(environmentController.userType, fakeSessionId);
             observer.eventHandler(event);
             assert.equal(messageToShow, undefined);
             assert.deepEqual(messageActions, []);

--- a/test/unitTests/observers/telemetryObserver.test.ts
+++ b/test/unitTests/observers/telemetryObserver.test.ts
@@ -2,12 +2,13 @@ import assert from 'assert';
 
 import { BuildInput } from '../../../src/build/buildInput';
 import { BuildResult } from '../../../src/build/buildResult';
-import { BuildCanceled, BuildFailed, BuildSucceeded, BuildTriggered, CancelBuildFailed,CancelBuildSucceeded, CancelBuildTriggered, DependencyInstallCompleted, DependencyInstallStarted, LearnMoreClicked, PackageInstallAttemptFailed, PackageInstallCompleted, QuickPickCommandSelected, QuickPickTriggered, UserSignInFailed, UserSignInSucceeded, UserSignInTriggered, UserSignOutFailed, UserSignOutSucceeded, UserSignOutTriggered,  } from '../../../src/common/loggingEvents';
+import { BuildCanceled, BuildFailed, BuildSucceeded, BuildTriggered, CancelBuildFailed, CancelBuildSucceeded, CancelBuildTriggered, DependencyInstallCompleted, DependencyInstallStarted, ExtensionActivated, LearnMoreClicked, PackageInstallAttemptFailed, PackageInstallCompleted, QuickPickCommandSelected, QuickPickTriggered, UserSignInFailed, UserSignInSucceeded, UserSignInTriggered, UserSignOutFailed, UserSignOutSucceeded, UserSignOutTriggered, } from '../../../src/common/loggingEvents';
 import { DocsError } from '../../../src/error/docsError';
 import { ErrorCode } from '../../../src/error/errorCode';
 import { TelemetryObserver } from '../../../src/observers/telemetryObserver';
+import { UserType } from '../../../src/shared';
 import TelemetryReporter from '../../../src/telemetryReporter';
-import { fakedCredential,fakedPackage } from '../../utils/faker';
+import { fakedCredential, fakedPackage } from '../../utils/faker';
 
 describe('TelemetryObserver', () => {
     let observer: TelemetryObserver;
@@ -250,11 +251,11 @@ describe('TelemetryObserver', () => {
         });
     });
 
-    describe('CancelBuildCompleted', ()=> {
+    describe('CancelBuildCompleted', () => {
         it('CancelBuildSucceeded', () => {
             const event = new CancelBuildSucceeded('FakedCorrelationId');
             observer.eventHandler(event);
-    
+
             assert.equal(sentEventName, 'CancelBuild.Completed');
             assert.deepStrictEqual(sentEventProperties, {
                 CorrelationId: 'FakedCorrelationId',
@@ -265,7 +266,7 @@ describe('TelemetryObserver', () => {
         it('CancelBuildFailed', () => {
             const event = new CancelBuildFailed('FakedCorrelationId');
             observer.eventHandler(event);
-    
+
             assert.equal(sentEventName, 'CancelBuild.Completed');
             assert.deepStrictEqual(sentEventProperties, {
                 CorrelationId: 'FakedCorrelationId',
@@ -381,6 +382,19 @@ describe('TelemetryObserver', () => {
         assert.deepStrictEqual(sentEventProperties, {
             CorrelationId: 'fakedCorrelationId',
             ErrorCode: 'fakedErrorCode'
+        });
+    });
+
+    describe(`Extension activated`, () => {
+        it(`SessionInfo should be sent`, () => {
+            const fakeSessionId = 'fakeSessionId';
+            const event = new ExtensionActivated(UserType.MicrosoftEmployee, fakeSessionId);
+            observer.eventHandler(event);
+            assert.equal(sentEventName, 'SessionInfo');
+            assert.deepStrictEqual(sentEventProperties, {
+                SessionId: fakeSessionId,
+                UserRole: UserType.MicrosoftEmployee
+            })
         });
     });
 });


### PR DESCRIPTION
[AB#367759](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/367759)
Session info event can be found here: [link](https://ms.portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22%3A%224192a661-6460-11eb-83e3-61d8390583c2%22%2C%22cacheId%22%3A%22f9d01925-3c03-4712-82b9-0e7d0f4dfa9c%22%2C%22eventTable%22%3A%22customEvents%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A1209600000%2C%22createdTime%22%3A%222021-02-01T07%3A44%3A20.645Z%22%2C%22isInitialTime%22%3Afalse%2C%22grain%22%3A1%2C%22useDashboardTimeRange%22%3Afalse%7D%7D/ComponentId/%7B%22SubscriptionId%22%3A%22fef9897e-e4c6-451a-9e2e-850f9876fdc7%22%2C%22ResourceGroup%22%3A%22local-build%22%2C%22Name%22%3A%22docs-validation-vscode-extension-prod%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%2Fsubscriptions%2Ffef9897e-e4c6-451a-9e2e-850f9876fdc7%2FresourceGroups%2Flocal-build%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fdocs-validation-vscode-extension-prod%22%2C%22ResourceType%22%3A%22microsoft.insights%2Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D)